### PR TITLE
Bug/anson/240 Add new diagnostic bug

### DIFF
--- a/components/records/ConsultationForm.js
+++ b/components/records/ConsultationForm.js
@@ -58,9 +58,9 @@ export function ConsultationForm({
           }`}
           name="category"
           onChange={e => handleDiagnosisChange(e, index)}
-          value={diagnosis.category}
+          value={diagnosis.category || 'nil'}
         >
-          <option disabled selected>
+          <option disabled value="nil">
             Please select...
           </option>
           {diagnosisOptions.map((option, optionIndex) => (

--- a/components/records/ConsultationForm.js
+++ b/components/records/ConsultationForm.js
@@ -72,7 +72,7 @@ export function ConsultationForm({
 
         <Button
           colour="red"
-          text="Delete Assessment"
+          text="Delete Diagnosis"
           onClick={() => handleDiagnosisDelete(index)}
         />
       </div>


### PR DESCRIPTION
Bug Fix #240  and changed naming to be consistent.

Current issue is caused when category is not set, hence the default option is not selected. I think why the 1st option is not re-rendered is because the key is not changed, so react think that it is the same element and need not render it. The key is only dependent on which position the diagnosis is in, and is not unique for each diagnosis. 

As a temporary fix, I had make it such that whenever `diagnosis.category` is not defined, it will just select the 1st option.