### PR TITLE
Fixing open sidebar button visibility when hidden

### DIFF
--- a/components/layout.js
+++ b/components/layout.js
@@ -45,7 +45,7 @@ function Layout(props) {
         <div>
           {!sidebarOpen && (
             <div
-              className="absolute top-1/2 left-0 transform -translate-y-1/2 w-2 h-16 bg-gray-700 rounded-r-md cursor-pointer z-10 md:hidden"
+              className="fixed top-1/2 left-0 transform -translate-y-1/2 w-2 h-16 bg-gray-700 rounded-r-md cursor-pointer z-10 md:hidden"
               onClick={() => onSetSidebarOpen(true)}
             ></div>
           )}


### PR DESCRIPTION
Currently, when scrolling down the page in mobile view, the button to expand it is not always visible.