### PR TITLE
Fix visit crashing bug

### DIFF
--- a/pages/records/patient-record/index.js
+++ b/pages/records/patient-record/index.js
@@ -147,7 +147,7 @@ const PatientRecord = () => {
   }
 
   const handleVisitChange = useCallback(event => {
-    const visitID = event.target.value;
+    const visitID = Number(event.target.value);
     loadVisitDetails(visitID);
   }, []);
 


### PR DESCRIPTION
- For some reason `event.target.value` is a string, and needs to be converted to a Number for visitID, otherwise the visit won't be found due to comparision between a string visitID and number visitID, causing undefined error