### PR TITLE
Patient Records: Fetch patients filtered on backend via QueryParams

### DIFF
--- a/hooks/useCachedVillageCode.js
+++ b/hooks/useCachedVillageCode.js
@@ -4,8 +4,8 @@ import { useContext, useEffect, useState } from 'react';
 export const VILLAGE_CODE_ALL = 'ALL';
 
 export default function useCachedVillageCode() {
-  const [villageCode, setVillageCode] = useState(VILLAGE_CODE_ALL);
   const { village } = useContext(VillageContext);
+  const [villageCode, setVillageCode] = useState(village);
   useEffect(() => {
     setVillageCode(village);
   }, [village]);

--- a/pages/records/index.js
+++ b/pages/records/index.js
@@ -59,7 +59,9 @@ function PatientList() {
 
   const fetchPatients = useWithLoading(async () => {
     try {
-      const response = await axiosInstance.get('/patients');
+      const response = await axiosInstance.get(
+        `/patients${villageCode === VILLAGE_CODE_ALL ? '' : '?village_code=' + villageCode.toLowerCase()}`
+      );
       setPatients(response.data);
       setPatientsFiltered(response.data);
     } catch (error) {
@@ -70,7 +72,7 @@ function PatientList() {
 
   useEffect(() => {
     fetchPatients();
-  }, []);
+  }, [villageCode]);
 
   useEffect(() => {
     filterPatients();
@@ -96,13 +98,8 @@ function PatientList() {
   }
 
   function filterPatients() {
-    console.log(villageCode);
     const filteredPatients = patients.filter(patient => {
-      return (
-        patient.filter_string.toLowerCase().trim().includes(patientSearch) &&
-        (villageCode === VILLAGE_CODE_ALL ||
-          patient.village_prefix === villageCode)
-      );
+      return patient.filter_string.toLowerCase().trim().includes(patientSearch);
     });
     console.dir(filteredPatients);
     setPatientsFiltered(filteredPatients);


### PR DESCRIPTION
Changed patient fetch logic such that the filtering is done via the query params in the API call to the backend instead of fetching every patient and filtering on the frontend