### PR TITLE
Date standardisation on frontend

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "@types/react-autosuggest": "^10.1.11",
     "@types/react-modal": "^3.16.3",
     "axios": "^1.9.0",
+    "luxon": "^3.7.1",
     "moment": "^2.30.1",
     "next": "^15.3.2",
     "react": "^19.1.0",
@@ -28,6 +29,7 @@
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3.3.1",
+    "@types/luxon": "^3.7.1",
     "@types/node": "^20.17.50",
     "@types/react": "^19.1.5",
     "@types/react-dom": "^19.1.5",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,6 @@
     "@types/react-modal": "^3.16.3",
     "axios": "^1.9.0",
     "luxon": "^3.7.1",
-    "moment": "^2.30.1",
     "next": "^15.3.2",
     "react": "^19.1.0",
     "react-autosuggest": "^10.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,6 +23,9 @@ importers:
       axios:
         specifier: ^1.9.0
         version: 1.9.0
+      luxon:
+        specifier: ^3.7.1
+        version: 3.7.1
       moment:
         specifier: ^2.30.1
         version: 2.30.1
@@ -57,6 +60,9 @@ importers:
       '@eslint/eslintrc':
         specifier: ^3.3.1
         version: 3.3.1
+      '@types/luxon':
+        specifier: ^3.7.1
+        version: 3.7.1
       '@types/node':
         specifier: ^20.17.50
         version: 20.17.50
@@ -433,6 +439,9 @@ packages:
 
   '@types/json5@0.0.29':
     resolution: {integrity: sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==}
+
+  '@types/luxon@3.7.1':
+    resolution: {integrity: sha512-H3iskjFIAn5SlJU7OuxUmTEpebK6TKB8rxZShDslBMZJ5u9S//KM1sbdAisiSrqwLQncVjnpi2OK2J51h+4lsg==}
 
   '@types/node@20.17.50':
     resolution: {integrity: sha512-Mxiq0ULv/zo1OzOhwPqOA13I81CV/W3nvd3ChtQZRT5Cwz3cr0FKo/wMSsbTqL3EXpaBAEQhva2B8ByRkOIh9A==}
@@ -1470,6 +1479,10 @@ packages:
 
   lru-cache@10.4.3:
     resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
+
+  luxon@3.7.1:
+    resolution: {integrity: sha512-RkRWjA926cTvz5rAb1BqyWkKbbjzCGchDUIKMCUvNi17j6f6j8uHGDV82Aqcqtzd+icoYpELmG3ksgGiFNNcNg==}
+    engines: {node: '>=12'}
 
   math-intrinsics@1.1.0:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
@@ -2512,6 +2525,8 @@ snapshots:
   '@types/json-schema@7.0.15': {}
 
   '@types/json5@0.0.29': {}
+
+  '@types/luxon@3.7.1': {}
 
   '@types/node@20.17.50':
     dependencies:
@@ -3727,6 +3742,8 @@ snapshots:
       js-tokens: 4.0.0
 
   lru-cache@10.4.3: {}
+
+  luxon@3.7.1: {}
 
   math-intrinsics@1.1.0: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,9 +26,6 @@ importers:
       luxon:
         specifier: ^3.7.1
         version: 3.7.1
-      moment:
-        specifier: ^2.30.1
-        version: 2.30.1
       next:
         specifier: ^15.3.2
         version: 15.3.2(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
@@ -1528,9 +1525,6 @@ packages:
   minipass@7.1.2:
     resolution: {integrity: sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==}
     engines: {node: '>=16 || 14 >=14.17'}
-
-  moment@2.30.1:
-    resolution: {integrity: sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how==}
 
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
@@ -3777,8 +3771,6 @@ snapshots:
   minimist@1.2.8: {}
 
   minipass@7.1.2: {}
-
-  moment@2.30.1: {}
 
   ms@2.1.3: {}
 

--- a/src/app/pharmacy/orders/page.tsx
+++ b/src/app/pharmacy/orders/page.tsx
@@ -10,6 +10,7 @@ import { useLoadingState } from '@/hooks/useLoadingState';
 import { Diagnosis } from '@/types/Diagnosis';
 import { OrderWithDiagnoses } from '@/types/Order';
 import { Patient } from '@/types/Patient';
+import { formatDate } from '@/utils/formatDate';
 import { CheckIcon, XMarkIcon } from '@heroicons/react/16/solid';
 import Image from 'next/image';
 import { Suspense, useEffect, useState } from 'react';
@@ -159,7 +160,10 @@ function OrderRow({
         <p className="text-nowrap text-gray-400">
           {orders == undefined || orders[0] == undefined
             ? 'Error Getting Date'
-            : new Date(orders[0].visit.date).toLocaleString()}
+            : formatDate(
+                new Date(orders[0].visit.date).toLocaleString(),
+                'datetime'
+              )}
         </p>
       </td>
       <td className="min-w-60 text-gray-700">

--- a/src/app/pharmacy/orders/page.tsx
+++ b/src/app/pharmacy/orders/page.tsx
@@ -159,11 +159,8 @@ function OrderRow({
         <p className="font-semibold">{patient.name}</p>
         <p className="text-nowrap text-gray-400">
           {orders == undefined || orders[0] == undefined
-            ? 'Error Getting Date'
-            : formatDate(
-                new Date(orders[0].visit.date).toLocaleString(),
-                'datetime'
-              )}
+            ? 'No Date'
+            : formatDate(orders[0].visit.date, 'datetime')}
         </p>
       </td>
       <td className="min-w-60 text-gray-700">

--- a/src/app/pharmacy/stock/HistoryMedicationModal.tsx
+++ b/src/app/pharmacy/stock/HistoryMedicationModal.tsx
@@ -4,6 +4,7 @@ import { LoadingUI } from '@/components/LoadingUI';
 import { getMedicationReviewById } from '@/data/medicationReview/getMedicationReview';
 import { useLoadingState } from '@/hooks/useLoadingState';
 import { MedicationReview } from '@/types/MedicationReview';
+import { formatDate } from '@/utils/formatDate';
 import { useRouter, useSearchParams } from 'next/navigation';
 import { useEffect, useState } from 'react';
 import ReactModal from 'react-modal';
@@ -114,7 +115,7 @@ function MedicationHistoryRow({ history }: { history: MedicationReview }) {
         {qty_changed >= 0 ? `+${qty_changed}` : qty_changed}
       </td>
       <td>{history.quantity_remaining}</td>
-      <td>{new Date(history.date).toLocaleString()}</td>
+      <td>{formatDate(history.date, 'datetime')}</td>
     </tr>
   );
 }

--- a/src/app/referrals/ReferralCard.tsx
+++ b/src/app/referrals/ReferralCard.tsx
@@ -14,7 +14,7 @@ export default function ReferralCard({
 }: {
   referral: Referral;
   patient: Patient;
-  date: Date;
+  date: string;
 }) {
   return (
     <tr>
@@ -46,7 +46,7 @@ export default function ReferralCard({
             </p>
             <p className="text-center">Name: {patient.name}</p>
             <p className="text-center">
-              Visited on: {formatDate(new Date(date).toDateString(), 'date')}
+              Visited on: {formatDate(date, 'date')}
             </p>
           </div>
         </div>

--- a/src/app/referrals/ReferralCard.tsx
+++ b/src/app/referrals/ReferralCard.tsx
@@ -3,6 +3,7 @@ import ReferralStateDropdown from '@/components/referrals/ReferralStateDropdown'
 import { VILLAGES } from '@/constants';
 import { Patient } from '@/types/Patient';
 import { Referral } from '@/types/Referral';
+import { formatDate } from '@/utils/formatDate';
 import Image from 'next/image';
 import Link from 'next/link';
 
@@ -45,7 +46,7 @@ export default function ReferralCard({
             </p>
             <p className="text-center">Name: {patient.name}</p>
             <p className="text-center">
-              Visited on: {new Date(date).toDateString()}
+              Visited on: {formatDate(new Date(date).toDateString(), 'date')}
             </p>
           </div>
         </div>

--- a/src/app/referrals/[id]/page.tsx
+++ b/src/app/referrals/[id]/page.tsx
@@ -8,6 +8,7 @@ import { patchReferral } from '@/data/referrals/patchReferral';
 import { useLoadingState } from '@/hooks/useLoadingState';
 import { Patient } from '@/types/Patient';
 import { Referral } from '@/types/Referral';
+import { formatDate } from '@/utils/formatDate';
 import { useParams } from 'next/navigation';
 import { useEffect, useState } from 'react';
 import toast from 'react-hot-toast';
@@ -79,7 +80,7 @@ export default function ReferralDetailsPage() {
                 <td>
                   {date == undefined
                     ? 'No Date'
-                    : new Date(date).toDateString()}
+                    : formatDate(new Date(date).toDateString(), 'date')}
                 </td>
               </tr>
               <tr>

--- a/src/app/referrals/[id]/page.tsx
+++ b/src/app/referrals/[id]/page.tsx
@@ -15,7 +15,7 @@ import toast from 'react-hot-toast';
 
 export default function ReferralDetailsPage() {
   const { isLoading, withLoading } = useLoadingState(true);
-  const [date, setDate] = useState<Date>();
+  const [date, setDate] = useState<string>();
   const [patient, setPatient] = useState<Patient>();
   const [referral, setReferral] = useState<Referral>();
   const [editable, setEditable] = useState<boolean>(false);
@@ -78,9 +78,7 @@ export default function ReferralDetailsPage() {
               <tr>
                 <td className="whitespace-nowrap">Referral Date</td>
                 <td>
-                  {date == undefined
-                    ? 'No Date'
-                    : formatDate(new Date(date).toDateString(), 'date')}
+                  {date == undefined ? 'No Date' : formatDate(date, 'date')}
                 </td>
               </tr>
               <tr>

--- a/src/components/VisitDropdown.tsx
+++ b/src/components/VisitDropdown.tsx
@@ -1,6 +1,6 @@
 'use client';
 import { Visit } from '@/types/Visit';
-import moment from 'moment';
+import { formatDate } from '@/utils/formatDate';
 import { usePathname, useRouter, useSearchParams } from 'next/navigation';
 import { useEffect, useMemo, useState } from 'react';
 
@@ -55,7 +55,7 @@ export function VisitDropdown({ name, visits }: DropdownProps) {
         </option>
         {visits.map(({ date: label, id: value }) => (
           <option value={value} key={value}>
-            {moment(label).format('DD MMM YYYY HH:mm')}
+            {formatDate(label, 'datetime')}
           </option>
         ))}
       </select>

--- a/src/components/records/UploadDocument.tsx
+++ b/src/components/records/UploadDocument.tsx
@@ -2,7 +2,7 @@
 import { postUpload } from '@/data/fileUpload/postUpload';
 import { useLoadingState } from '@/hooks/useLoadingState';
 import { Patient } from '@/types/Patient';
-import moment from 'moment';
+import { DateTime } from 'luxon';
 import { useState } from 'react';
 import { FormProvider, useForm } from 'react-hook-form';
 import toast from 'react-hot-toast';
@@ -39,7 +39,7 @@ export function UploadDocument({ patient }: { patient: Patient }) {
                   async vals => {
                     const file = vals.file[0];
 
-                    const currentDate = moment().format('YYYY-MM-DD');
+                    const currentDate = DateTime.now().toFormat('yyyy-MM-dd');
                     const patientIdentifier = patient.patient_id;
                     const documentName: string =
                       vals.file_name == ''

--- a/src/components/records/ViewDocument.tsx
+++ b/src/components/records/ViewDocument.tsx
@@ -3,6 +3,7 @@
 import { getUploadByPatientId } from '@/data/fileUpload/getUpload';
 import { Patient } from '@/types/Patient';
 import { Upload } from '@/types/Upload';
+import { formatDate } from '@/utils/formatDate';
 import Link from 'next/link';
 import { useEffect, useState } from 'react';
 import ReactModal from 'react-modal';
@@ -49,7 +50,7 @@ export function ViewDocument({ patient }: { patient: Patient }) {
                     {doc.file_name}
                   </Link>
                 </td>
-                <td>{new Date(doc.created_at).toLocaleString()}</td>
+                <td>{formatDate(doc.created_at, 'datetime')}</td>
               </tr>
             ))}
           </tbody>

--- a/src/components/records/patient/PatientInfoDetailSection.tsx
+++ b/src/components/records/patient/PatientInfoDetailSection.tsx
@@ -1,5 +1,5 @@
 import { Patient } from '@/types/Patient';
-import moment from 'moment';
+import { formatDate } from '@/utils/formatDate';
 import { DisplayField } from '../../DisplayField';
 
 export function PatientInfoDetailSection({ patient }: { patient: Patient }) {
@@ -10,7 +10,7 @@ export function PatientInfoDetailSection({ patient }: { patient: Patient }) {
     { label: 'Gender', value: patient.gender },
     {
       label: 'Date of Birth',
-      value: moment(patient.date_of_birth).format('DD-MMMM-YYYY'),
+      value: formatDate(patient.date_of_birth, 'date'),
     },
     { label: 'Village', value: patient.village_prefix },
     { label: 'POOR', value: patient.poor },

--- a/src/data/referrals/getReferrals.ts
+++ b/src/data/referrals/getReferrals.ts
@@ -6,7 +6,7 @@ import { Referral } from '@/types/Referral';
 export type ReferralWithDetails = {
   patient: Patient;
   referral: Referral;
-  date: Date;
+  date: string;
 };
 
 export async function getReferrals(): Promise<ReferralWithDetails[]> {

--- a/src/data/visit/createVisit.ts
+++ b/src/data/visit/createVisit.ts
@@ -1,12 +1,12 @@
 'use server';
 import { axiosInstance } from '@/lib/axiosInstance';
 import { Patient } from '@/types/Patient';
-import moment from 'moment';
+import { formatDate } from '@/utils/formatDate';
 
 export async function createVisit(patient: Patient) {
   await axiosInstance.post(`/visits/`, {
     patient_id: patient.pk,
-    visit_date: moment().format('DD MMMM YYYY HH:mm'),
+    visit_date: formatDate(),
     status: 'started',
   });
 }

--- a/src/utils/formatDate.ts
+++ b/src/utils/formatDate.ts
@@ -1,16 +1,17 @@
-import moment from 'moment';
+import { DateTime } from 'luxon';
 
 export function formatDate(
   date?: string,
   format?: 'date' | 'datetime'
 ): string {
-  if (format == 'datetime') {
-    return date
-      ? moment(date).format('DD MMM YYYY HH:mm')
-      : moment().format('DD MMM YYYY HH:mm');
+  if (!date) {
+    return format === 'datetime'
+      ? DateTime.now().toFormat('dd MMM yyyy HH:mm')
+      : DateTime.now().toFormat('dd MMM yyyy');
   } else {
-    return date
-      ? moment(date).format('DD MMM YYYY')
-      : moment().format('DD MMM YYYY');
+    const dt = DateTime.fromISO(date);
+    return format === 'date'
+      ? dt.toFormat('dd MMM yyyy')
+      : dt.toFormat('dd MMM yyyy HH:mm');
   }
 }

--- a/src/utils/formatDate.ts
+++ b/src/utils/formatDate.ts
@@ -1,5 +1,12 @@
 import { DateTime } from 'luxon';
 
+/**
+ * Formats a date string or DateTime object into a human-readable format.
+ * @param date - The date string in ISO format. YYYY-MM-DDTHH:mm:ss.sssZ
+ * @param format - The format to return the date in.
+ *    - `date` for just the date, eg '07 Aug 2025',
+ *    - `datetime` for date and time, eg '07 Aug 2025 14:30'.
+ */
 export function formatDate(
   date?: string,
   format?: 'date' | 'datetime'

--- a/src/utils/formatDate.ts
+++ b/src/utils/formatDate.ts
@@ -1,0 +1,16 @@
+import moment from 'moment';
+
+export function formatDate(
+  date?: string,
+  format?: 'date' | 'datetime'
+): string {
+  if (format == 'datetime') {
+    return date
+      ? moment(date).format('DD MMM YYYY HH:mm')
+      : moment().format('DD MMM YYYY HH:mm');
+  } else {
+    return date
+      ? moment(date).format('DD MMM YYYY')
+      : moment().format('DD MMM YYYY');
+  }
+}


### PR DESCRIPTION
closes #32 

Standardise date formats. Use Luxon instead of moment (deprecated).

To standardise dates, use formatDate().