### PR TITLE
"No documents found" shown when no documents are uploaded

### DIFF
--- a/src/components/records/ViewDocument.tsx
+++ b/src/components/records/ViewDocument.tsx
@@ -59,76 +59,82 @@ export function ViewDocument({ patient }: { patient: Patient }) {
         onRequestClose={() => setIsOpen(false)}
         ariaHideApp={false}
       >
-        <table className="w-full table-fixed divide-y divide-gray-400 text-left">
-          <colgroup>
-            <col className="w-1/2" />
-            <col className="w-1/4" />
-            <col className="w-1/4" />
-          </colgroup>
-          <thead>
-            <tr>
-              <th className="px-2 py-1">File Name</th>
-              <th className="px-2 py-1">Created At</th>
-              <th className="px-2 py-1">Actions</th>
-            </tr>
-          </thead>
-          <tbody className="divide-y divide-gray-200">
-            {documents.map(doc => (
-              <tr key={doc.id}>
-                <td className="px-2 py-1">
-                  {editingId === doc.id ? (
-                    <input
-                      type="text"
-                      value={newFileName}
-                      onChange={e => setNewFileName(e.target.value)}
-                      className="w-full rounded border px-2 py-1"
-                    />
-                  ) : (
-                    <Link
-                      href={doc.file_path || doc.offline_file || '#'}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      className="text-blue-600 underline"
-                    >
-                      {doc.file_name}
-                    </Link>
-                  )}
-                </td>
-                <td className="px-2 py-1">
-                  {formatDate(doc.created_at, 'datetime')}
-                </td>
-                <td className="px-2 py-1">
-                  {editingId === doc.id ? (
-                    <div className="flex space-x-2">
-                      <Button
-                        text="Save"
-                        colour="green"
-                        onClick={() => handleRename(doc)}
+        {documents.length === 0 ? (
+          <div className="px-2 py-4 text-center text-gray-500">
+            No documents found.
+          </div>
+        ) : (
+          <table className="w-full table-fixed divide-y divide-gray-400 text-left">
+            <colgroup>
+              <col className="w-1/2" />
+              <col className="w-1/4" />
+              <col className="w-1/4" />
+            </colgroup>
+            <thead>
+              <tr>
+                <th className="px-2 py-1">File Name</th>
+                <th className="px-2 py-1">Created At</th>
+                <th className="px-2 py-1">Actions</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-gray-200">
+              {documents.map(doc => (
+                <tr key={doc.id}>
+                  <td className="px-2 py-1">
+                    {editingId === doc.id ? (
+                      <input
+                        type="text"
+                        value={newFileName}
+                        onChange={e => setNewFileName(e.target.value)}
+                        className="w-full rounded border px-2 py-1"
                       />
+                    ) : (
+                      <Link
+                        href={doc.file_path || doc.offline_file || '#'}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="text-blue-600 underline"
+                      >
+                        {doc.file_name}
+                      </Link>
+                    )}
+                  </td>
+                  <td className="px-2 py-1">
+                    {formatDate(doc.created_at, 'datetime')}
+                  </td>
+                  <td className="px-2 py-1">
+                    {editingId === doc.id ? (
+                      <div className="flex space-x-2">
+                        <Button
+                          text="Save"
+                          colour="green"
+                          onClick={() => handleRename(doc)}
+                        />
+                        <Button
+                          text="Cancel"
+                          colour="red"
+                          onClick={() => {
+                            setEditingId(null);
+                            setNewFileName('');
+                          }}
+                        />
+                      </div>
+                    ) : (
                       <Button
-                        text="Cancel"
-                        colour="red"
+                        text="Edit"
+                        colour="green"
                         onClick={() => {
-                          setEditingId(null);
-                          setNewFileName('');
+                          setEditingId(doc.id);
+                          setNewFileName(doc.file_name);
                         }}
                       />
-                    </div>
-                  ) : (
-                    <Button
-                      text="Edit"
-                      colour="green"
-                      onClick={() => {
-                        setEditingId(doc.id);
-                        setNewFileName(doc.file_name);
-                      }}
-                    />
-                  )}
-                </td>
-              </tr>
-            ))}
-          </tbody>
-        </table>
+                    )}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        )}
         <Button text="Close" onClick={() => setIsOpen(false)} colour="red" />
       </ReactModal>
     </>


### PR DESCRIPTION
This PR addresses issue #67, hiding table headers and showing "No documents found." when no documents have been uploaded

<img width="841" height="218" alt="image" src="https://github.com/user-attachments/assets/55db32f9-8897-4d8d-a64a-3daf698a3e83" />
