### PR TITLE
Create new medication does not allow user to submit if quantity is missing

### DIFF
--- a/src/components/pharmacy/MedicationForm.tsx
+++ b/src/components/pharmacy/MedicationForm.tsx
@@ -42,6 +42,7 @@ export function MedicationForm({
           label="Quantity to Add (Negative to subtract)"
           name="quantity_changed"
           type="number"
+          isRequired={true}
         />
         <RHFInputField label="Notes" name="notes" type="text" />
         <div className="flex">


### PR DESCRIPTION
This PR addresses issue https://github.com/NUS-Project-SaBai/FrontEnd/issues/74 by adding client-side validation to the Quantity to Add field, blocking form submission if the field is empty or invalids and prevents unnecessary API calls to the backend (no backend error)

<img width="862" height="669" alt="491391841-e03cd80e-3311-478f-aa2a-718244a75ad5" src="https://github.com/user-attachments/assets/4251113b-86bd-42d4-9688-aeb414e47a7d" />
