### PR TITLE
Viewing all consults data with dates of consultation displayed

### DIFF
--- a/src/app/records/patient-consultation/api.ts
+++ b/src/app/records/patient-consultation/api.ts
@@ -26,3 +26,19 @@ export async function fetchPatientConsultationInfo(visitId: number): Promise<{
     .get(`/patient_consult/?visit_id=${visitId}`)
     .then(res => res.data);
 }
+
+export type AllConsults = Awaited<
+  ReturnType<typeof fetchPatientConsultationInfo>
+>;
+
+export async function fetchAllConsultsByPatientId(
+  patientId: string
+): Promise<AllConsults[]> {
+  const visits = await axiosInstance
+    .get(`/visits/?patient=${patientId}`)
+    .then(res => res.data);
+  const consults = await Promise.all(
+    visits.map((v: { id: number }) => fetchPatientConsultationInfo(v.id))
+  );
+  return consults;
+}

--- a/src/components/records/consultation/AllConsultationTable.tsx
+++ b/src/components/records/consultation/AllConsultationTable.tsx
@@ -1,0 +1,139 @@
+'use client';
+import { Button } from '@/components/Button';
+import { DisplayField } from '@/components/DisplayField';
+import { LoadingUI } from '@/components/LoadingUI';
+import { DiagnosesTable } from '@/components/records/consultation/DiagnosesTable';
+import { PrescriptionTable } from '@/components/records/prescription/PrescriptionTable';
+import { getConsultByID } from '@/data/consult/getConsult';
+import { getPdfConsult } from '@/data/consult/getPdfConsult';
+import { getDiagnosisByConsult } from '@/data/diagnosis/getDiagnosis';
+import { useLoadingState } from '@/hooks/useLoadingState';
+import { Consult } from '@/types/Consult';
+import { Diagnosis } from '@/types/Diagnosis';
+import { useEffect, useState } from 'react';
+import ReactModal from 'react-modal';
+import { AllConsultationTableRow } from './AllConsultationTableRow';
+
+export function AllConsultationTable({
+  consults,
+}: {
+  consults: Pick<Consult, 'id' | 'date' | 'doctor' | 'referred_for'>[] | null;
+}) {
+  const [consultId, setConsultId] = useState<number | null>(null);
+  const [consult, setConsult] = useState<Consult | null>(null);
+  const [diagnosisArray, setDiagnosisArray] = useState<Diagnosis[]>([]);
+  const { isLoading, withLoading } = useLoadingState(true);
+  const closeModal = () => {
+    setConsultId(null);
+    setConsult(null);
+    setDiagnosisArray([]);
+  };
+
+  useEffect(() => {
+    if (consultId == null) return;
+    withLoading(async () => {
+      await Promise.all([
+        getConsultByID(consultId.toString()).then(setConsult),
+        getDiagnosisByConsult(consultId).then(setDiagnosisArray),
+      ]);
+    })();
+  }, [consultId]);
+
+  if (consults == null) {
+    return <LoadingUI message="Loading Consultations..." />;
+  } else if (consults.length === 0) {
+    return <p>No Consultations Found</p>;
+  }
+
+  return (
+    <>
+      <ReactModal
+        isOpen={consultId != null}
+        onRequestClose={closeModal}
+        ariaHideApp={false}
+      >
+        {isLoading ? (
+          <LoadingUI message="Loading Consultation..." />
+        ) : consult == null ? (
+          <p>No Consult Found</p>
+        ) : (
+          <>
+            <div>
+              <DisplayField
+                label="Consultation done by"
+                content={consult.doctor.nickname || ''}
+              />
+              <DisplayField
+                label="Past Medical History"
+                content={consult.past_medical_history || 'NIL'}
+              />
+              <DisplayField
+                label="Consultation"
+                content={consult.consultation || 'NIL'}
+              />
+              <DisplayField label="Plan" content={consult.plan} />
+              <DisplayField
+                label="Referred for"
+                content={consult.referred_for || 'NIL'}
+              />
+              <DisplayField
+                label="Referred Notes"
+                content={consult.referral_notes || 'NIL'}
+              />
+              <DisplayField
+                label="Remarks"
+                content={consult.remarks || 'NIL'}
+              />
+              <div className="py-2">
+                <p className="font-bold">Diagnoses</p>
+                <DiagnosesTable diagnoses={diagnosisArray} />
+              </div>
+              <div className="py-2">
+                <p className="font-bold">Prescriptions</p>
+                <PrescriptionTable
+                  prescriptions={
+                    consult?.prescriptions.map(p => ({
+                      consult_id: p.consult,
+                      visit_date: p.visit.date,
+                      medication: p.medication_review.medicine.medicine_name,
+                      quantity: p.medication_review.quantity_changed,
+                      notes: p.notes,
+                      status: p.medication_review.order_status,
+                    })) || []
+                  }
+                />
+              </div>
+            </div>
+            <Button onClick={closeModal} text="Close" colour="red" />
+          </>
+        )}
+      </ReactModal>
+      <table className="rounded-table text-left">
+        <thead className="bg-gray-50">
+          <tr>
+            <th>Date</th>
+            <th>Doctor</th>
+            <th>Referral Type</th>
+            <th>Action</th>
+          </tr>
+        </thead>
+        <tbody>
+          {consults.map(consult => (
+            <AllConsultationTableRow
+              key={consult.id}
+              consult={consult}
+              openConsultModal={setConsultId}
+              onGeneratePDF={() => {
+                getPdfConsult(consult.id).then(payload => {
+                  if (payload == null) return;
+                  const url = URL.createObjectURL(payload);
+                  window.open(url, '_blank');
+                });
+              }}
+            />
+          ))}
+        </tbody>
+      </table>
+    </>
+  );
+}

--- a/src/components/records/consultation/AllConsultationTableRow.tsx
+++ b/src/components/records/consultation/AllConsultationTableRow.tsx
@@ -1,0 +1,26 @@
+import { Button } from '@/components/Button';
+import { Consult } from '@/types/Consult';
+
+export function AllConsultationTableRow({
+  consult,
+  openConsultModal,
+  onGeneratePDF,
+}: {
+  consult: Pick<Consult, 'id' | 'date' | 'doctor' | 'referred_for'>;
+  openConsultModal: (consultId: number) => void;
+  onGeneratePDF: () => void;
+}) {
+  return (
+    <tr>
+      <td>{consult.date.split('T')[0]}</td>
+      <td>{consult.doctor.nickname}</td>
+      <td>{consult.referred_for || 'Not Referred'}</td>
+      <td>
+        <Button text="View" onClick={() => openConsultModal(consult.id)} />
+      </td>
+      <td>
+        <Button text="Generate PDF" onClick={() => onGeneratePDF()} />
+      </td>
+    </tr>
+  );
+}


### PR DESCRIPTION
This PR addresses issue #43, adding a new table in the patient consultation page to view consultation data (including date) from all recorded patient visits