### PR TITLE
73-consult-bug

### DIFF
--- a/src/components/records/consultation/ConsultationForm.tsx
+++ b/src/components/records/consultation/ConsultationForm.tsx
@@ -232,7 +232,7 @@ export function ConsultationForm({
               label="Referral Notes"
               type="textarea"
               placeholder="Type your referral notes here..."
-              isRequired={true}
+              isRequired={useFormReturn.watch('referred_for') !== ''}
             />
           )}
 

--- a/src/components/records/consultation/ConsultationForm.tsx
+++ b/src/components/records/consultation/ConsultationForm.tsx
@@ -222,15 +222,20 @@ export function ConsultationForm({
               },
             ]}
           />
-          {useFormReturn.watch('referred_for') === '' || (
-            <RHFInputField
-              name="referral_notes"
-              label="Referral Notes"
-              type="textarea"
-              placeholder="Type your referral notes here..."
-              isRequired={useFormReturn.watch('referred_for') !== ''}
-            />
-          )}
+          {(() => {
+            const referredFor = useFormReturn.watch('referred_for');
+            return (
+              referredFor !== '' && (
+                <RHFInputField
+                  name="referral_notes"
+                  label="Referral Notes"
+                  type="textarea"
+                  placeholder="Type your referral notes here..."
+                  isRequired={true}
+                />
+              )
+            );
+          })()}
 
           <RHFInputField
             name="remarks"

--- a/src/components/records/consultation/ConsultationForm.tsx
+++ b/src/components/records/consultation/ConsultationForm.tsx
@@ -228,9 +228,7 @@ export function ConsultationForm({
               label="Referral Notes"
               type="textarea"
               placeholder="Type your referral notes here..."
-              isRequired={
-                useFormReturn.watch('referred_for') !== 'Not Referred'
-              }
+              isRequired={useFormReturn.watch('referred_for') !== ''}
             />
           )}
 

--- a/src/components/records/consultation/ConsultationForm.tsx
+++ b/src/components/records/consultation/ConsultationForm.tsx
@@ -235,7 +235,6 @@ export function ConsultationForm({
               isRequired={useFormReturn.watch('referred_for') !== ''}
             />
           )}
-
           <RHFInputField
             name="remarks"
             label="Remarks"

--- a/src/components/records/consultation/ConsultationForm.tsx
+++ b/src/components/records/consultation/ConsultationForm.tsx
@@ -49,6 +49,7 @@ export function ConsultationForm({
     reset,
     formState: { isSubmitting },
   } = useFormReturn;
+  const referredFor = useFormReturn.watch('referred_for');
 
   const submitConsultationFormHandler = (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
@@ -111,7 +112,7 @@ export function ConsultationForm({
 
         // only submit the form if 'referred_for' is filled in and is not 'Not Referred'
         if ('referred_for' in referralPayload) {
-          if (referralPayload['referred_for'] !== '') {
+          if (referralPayload['referred_for'] !== 'Not Referred') {
             if (!('referral_notes' in referralPayload)) {
               referralPayload['referral_notes'] = 'No notes entered';
             }
@@ -143,6 +144,8 @@ export function ConsultationForm({
       }
     )();
   };
+  const showReferralNotes = referredFor && referredFor !== 'Not Referred';
+
   return (
     <div className="h-full rounded-lg bg-blue-100 p-2 shadow-sm">
       <h3>Doctor&apos;s Consult Form</h3>
@@ -208,6 +211,7 @@ export function ConsultationForm({
             label="Referral for (optional)"
             omitDefaultPrompt={true}
             options={[
+              //use empty string '' for "Not Referred"
               { value: 'Not Referred', label: 'Not Referred' },
               { value: 'Diagnostic', label: 'Diagnositic' },
               { value: 'Acute', label: 'Acute' },
@@ -222,20 +226,15 @@ export function ConsultationForm({
               },
             ]}
           />
-          {(() => {
-            const referredFor = useFormReturn.watch('referred_for');
-            return (
-              referredFor !== '' && (
-                <RHFInputField
-                  name="referral_notes"
-                  label="Referral Notes"
-                  type="textarea"
-                  placeholder="Type your referral notes here..."
-                  isRequired={true}
-                />
-              )
-            );
-          })()}
+          {showReferralNotes && (
+            <RHFInputField
+              name="referral_notes"
+              label="Referral Notes"
+              type="textarea"
+              placeholder="Type your referral notes here..."
+              isRequired={true}
+            />
+          )}
 
           <RHFInputField
             name="remarks"


### PR DESCRIPTION
Description:
This PR aims to hide the referral notes when the option selected in the dropdown for 'Referred for (optional)'  is 'Not referred', to prevent users from entering details in referral notes when there's no referral. The change lies in conditionally rendering RHFInputField for referral_notes only when referred_for value !== ''.

Issue ticket number and link:
#73