### PR TITLE
Add Warning Quantity to Medication Stock

### DIFF
--- a/src/app/pharmacy/orders/api.ts
+++ b/src/app/pharmacy/orders/api.ts
@@ -17,7 +17,7 @@ export async function fetchAllPatientMedicationOrders(): Promise<
     };
     data: {
       orders: {
-        id: number;
+        order_id: number;
         medication_name: string;
         medication_code: string;
         quantity_changed: number;

--- a/src/app/pharmacy/orders/api.ts
+++ b/src/app/pharmacy/orders/api.ts
@@ -21,6 +21,7 @@ export async function fetchAllPatientMedicationOrders(): Promise<
         medication_name: string;
         medication_code: string;
         quantity_changed: number;
+        is_low_stock: boolean;
         notes: string;
       }[];
       diagnoses: { category: string; details: string }[];

--- a/src/app/pharmacy/orders/page.tsx
+++ b/src/app/pharmacy/orders/page.tsx
@@ -24,7 +24,7 @@ type OrderRowData = {
   };
   data: {
     orders: {
-      id: number;
+      order_id: number;
       medication_name: string;
       medication_code: string;
       quantity_changed: number;
@@ -181,13 +181,7 @@ function OrderRow({
                 >
                   <div>
                     {o.is_low_stock && (
-                      <p
-                        style={{
-                          color: '#cc0000',
-                          fontWeight: 'bold',
-                          marginBottom: '6px',
-                        }}
-                      >
+                      <p className="mb-1.5 font-bold text-red-600">
                         Warning: Low Stock!
                       </p>
                     )}
@@ -206,13 +200,13 @@ function OrderRow({
                   </div>
                   <ApproveRejectOrderButton
                     handleApproveOrder={async () => {
-                      await patchOrder(o.id.toString(), 'APPROVED')
-                        .then(() => removeNonPendingOrder(o.id))
+                      await patchOrder(o.order_id.toString(), 'APPROVED')
+                        .then(() => removeNonPendingOrder(o.order_id))
                         .catch(err => onPatchError(err, o.medication_name));
                     }}
                     handleCancelOrder={async () => {
-                      await patchOrder(o.id.toString(), 'CANCELLED')
-                        .then(() => removeNonPendingOrder(o.id))
+                      await patchOrder(o.order_id.toString(), 'CANCELLED')
+                        .then(() => removeNonPendingOrder(o.order_id))
                         .catch(err => onPatchError(err, o.medication_name));
                     }}
                   />

--- a/src/app/pharmacy/orders/page.tsx
+++ b/src/app/pharmacy/orders/page.tsx
@@ -10,6 +10,7 @@ import { useLoadingState } from '@/hooks/useLoadingState';
 import { VillagePrefix } from '@/types/VillagePrefixEnum';
 import { formatDate } from '@/utils/formatDate';
 import { CheckIcon, XMarkIcon } from '@heroicons/react/16/solid';
+import clsx from 'clsx';
 import { Suspense, useCallback, useEffect, useState } from 'react';
 import toast from 'react-hot-toast';
 import { fetchAllPatientMedicationOrders } from './api';
@@ -27,6 +28,7 @@ type OrderRowData = {
       medication_name: string;
       medication_code: string;
       quantity_changed: number;
+      is_low_stock: boolean;
       notes: string;
     }[];
     diagnoses: { category: string; details: string }[];
@@ -172,9 +174,23 @@ function OrderRow({
               {orders.map((o, i) => (
                 <div
                   key={i}
-                  className="flex justify-between p-1.5 text-sm text-gray-700 hover:bg-slate-100"
+                  className={clsx(
+                    'flex justify-between p-1.5 text-sm text-gray-700 hover:bg-slate-100', // base styling
+                    o.is_low_stock && 'bg-red-100' // highlight if low stock
+                  )}
                 >
                   <div>
+                    {o.is_low_stock && (
+                      <p
+                        style={{
+                          color: '#cc0000',
+                          fontWeight: 'bold',
+                          marginBottom: '6px',
+                        }}
+                      >
+                        Warning: Low Stock!
+                      </p>
+                    )}
                     <p>
                       <b>{o.medication_name}: </b>
                       {Math.abs(o.quantity_changed)}
@@ -222,7 +238,7 @@ function ApproveRejectOrderButton({
   return isUpdating ? (
     <LoadingUI message={actionStr} />
   ) : (
-    <div>
+    <div className="flex items-center gap-2">
       <Button
         text=""
         colour="green"

--- a/src/app/pharmacy/stock/page.tsx
+++ b/src/app/pharmacy/stock/page.tsx
@@ -36,9 +36,8 @@ export default function PharmacyStockPage() {
   return (
     <LoadingPage isLoading={isLoading} message="Loading Medications...">
       <div className="p-2">
-        <h2>Medication Stock</h2>
-        <div>
-          <label htmlFor="search">Search for Medicine</label>
+        <h1>Medication Stock</h1>
+        <div className="flex gap-x-2">
           <input
             id="search"
             type="search"
@@ -50,8 +49,8 @@ export default function PharmacyStockPage() {
               isLoading ? 'Loading Medicine...' : 'Search for Medicine'
             }
           />
+          <AddMedicationModal reloadAllMedications={fetchMedications} />
         </div>
-        <AddMedicationModal />
         <EditMedicationModal reloadAllMedications={fetchMedications} />
         <HistoryMedicationModal />
         <MedicationTable medications={filteredMedications} />

--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -96,7 +96,7 @@ export function Button({
   useEffect(() => setHydrated(true), []);
 
   const handleClick = async (e: MouseEvent<HTMLButtonElement>) => {
-    if (!onClick) return;
+    if (!onClick || !hydrated) return;
     const maybePromise = onClick(e);
     if (maybePromise instanceof Promise) {
       try {

--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -8,57 +8,129 @@ import {
   useState,
 } from 'react';
 
-export function Button({
-  text,
-  onClick = () => {},
-  type = 'button',
-  colour = 'white',
-  Icon = <></>,
-  ...props
-}: {
+type ButtonProps = {
   text?: string;
-  onClick?: (e: MouseEvent) => void;
+  onClick?: (e: MouseEvent<HTMLButtonElement>) => void | Promise<void>;
   type?: 'submit' | 'button' | 'reset';
   colour?: 'green' | 'red' | 'orange' | 'blue' | 'white' | 'indigo';
+  size?: 'sm' | 'md' | 'lg';
+  variant?: 'solid' | 'outline' | 'ghost';
   Icon?: ReactNode;
-} & ButtonHTMLAttributes<HTMLButtonElement>) {
-  const [isLoading, setIsLoading] = useState(true);
-  // makes the button interactive only when it is hydrated
-  useEffect(() => {
-    setIsLoading(false);
-  }, []);
+  fullWidth?: boolean;
+  className?: string;
+} & ButtonHTMLAttributes<HTMLButtonElement>;
 
-  const handleClick = async (e: MouseEvent) => {
-    try {
-      setIsLoading(true);
-      onClick(e);
-    } finally {
-      setIsLoading(false);
+const COLOUR_MAP: Record<
+  NonNullable<ButtonProps['colour']>,
+  {
+    solid: string;
+    outline: string;
+    ghost: string;
+  }
+> = {
+  green: {
+    solid:
+      'bg-green-600 text-white hover:bg-green-700 focus-visible:ring-green-600',
+    outline:
+      'border border-green-600 text-green-700 hover:bg-green-50 focus-visible:ring-green-600',
+    ghost: 'text-green-700 hover:bg-green-50 focus-visible:ring-green-600',
+  },
+  red: {
+    solid: 'bg-red-600 text-white hover:bg-red-700 focus-visible:ring-red-600',
+    outline:
+      'border border-red-600 text-red-700 hover:bg-red-50 focus-visible:ring-red-600',
+    ghost: 'text-red-700 hover:bg-red-50 focus-visible:ring-red-600',
+  },
+  orange: {
+    solid:
+      'bg-orange-600 text-white hover:bg-orange-700 focus-visible:ring-orange-600',
+    outline:
+      'border border-orange-600 text-orange-700 hover:bg-orange-50 focus-visible:ring-orange-600',
+    ghost: 'text-orange-700 hover:bg-orange-50 focus-visible:ring-orange-600',
+  },
+  blue: {
+    solid:
+      'bg-blue-600 text-white hover:bg-blue-700 focus-visible:ring-blue-600',
+    outline:
+      'border border-blue-600 text-blue-700 hover:bg-blue-50 focus-visible:ring-blue-600',
+    ghost: 'text-blue-700 hover:bg-blue-50 focus-visible:ring-blue-600',
+  },
+  indigo: {
+    solid:
+      'bg-indigo-600 text-white hover:bg-indigo-700 focus-visible:ring-indigo-600',
+    outline:
+      'border border-indigo-600 text-indigo-700 hover:bg-indigo-50 focus-visible:ring-indigo-600',
+    ghost: 'text-indigo-700 hover:bg-indigo-50 focus-visible:ring-indigo-600',
+  },
+  white: {
+    solid:
+      'bg-white border border-gray-300 text-gray-800 hover:bg-gray-50 focus-visible:ring-gray-400',
+    outline:
+      'border border-gray-300 text-gray-800 hover:bg-gray-50 focus-visible:ring-gray-400',
+    ghost: 'text-gray-800 hover:bg-gray-100 focus-visible:ring-gray-400',
+  },
+};
+
+const SIZE_MAP: Record<NonNullable<ButtonProps['size']>, string> = {
+  sm: 'px-3 py-1.5 text-sm',
+  md: 'px-4 py-2 text-sm',
+  lg: 'px-5 py-3 text-base',
+};
+
+export function Button({
+  text,
+  onClick,
+  type = 'button',
+  colour = 'white',
+  variant = 'solid',
+  size = 'md',
+  Icon,
+  fullWidth,
+  className,
+  ...props
+}: ButtonProps) {
+  const [hydrated, setHydrated] = useState(false);
+  const [isLoading, setIsLoading] = useState(false);
+
+  // Prevent SSR hydration mismatch
+  useEffect(() => setHydrated(true), []);
+
+  const handleClick = async (e: MouseEvent<HTMLButtonElement>) => {
+    if (!onClick) return;
+    const maybePromise = onClick(e);
+    if (maybePromise instanceof Promise) {
+      try {
+        setIsLoading(true);
+        await maybePromise;
+      } finally {
+        setIsLoading(false);
+      }
     }
   };
 
+  const colorStyles = COLOUR_MAP[colour][variant];
+  const sizeStyles = SIZE_MAP[size];
+  const baseStyles =
+    'inline-flex items-center justify-center gap-2 rounded-md font-medium transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 disabled:opacity-50 disabled:pointer-events-none';
+
   return (
     <button
-      className={
-        isLoading
-          ? 'rounded-md bg-gray-300 opacity-50 hover:cursor-default'
-          : `rounded-md p-2 shadow-sm hover:shadow hover:outline hover:outline-gray-400 ` +
-            (colour == 'white'
-              ? 'bg-white'
-              : `bg-${colour}-500 border-0 text-white`)
-      }
       type={type}
       onClick={handleClick}
-      disabled={isLoading}
+      disabled={!hydrated || isLoading || props.disabled}
+      className={`${baseStyles} ${sizeStyles} ${colorStyles} ${
+        fullWidth ? 'w-full' : ''
+      } ${className ?? ''}`}
       {...props}
     >
       {isLoading ? (
+        // You can replace this with your own spinner or <LoadingUI />
         <LoadingUI />
       ) : (
-        <div>
-          {Icon}
-          {text}
-        </div>
+        <>
+          {text && <span>{text}</span>}
+          {Icon && <span className="flex items-center">{Icon}</span>}
+        </>
       )}
     </button>
   );

--- a/src/components/inputs/RHFInputField.tsx
+++ b/src/components/inputs/RHFInputField.tsx
@@ -1,6 +1,6 @@
 'use client';
 import { HTMLInputTypeAttribute } from 'react';
-import { useFormContext } from 'react-hook-form';
+import { RegisterOptions, useFormContext } from 'react-hook-form';
 
 type RHFInputFieldProps = {
   name: string;
@@ -16,7 +16,8 @@ export function RHFInputField({
   type,
   placeholder = '',
   isRequired = false,
-}: RHFInputFieldProps) {
+  ...registerOptions
+}: RHFInputFieldProps & RegisterOptions) {
   const { register, formState } = useFormContext();
   const curFormErrorState = formState?.errors[name];
   const inputClassStyle =
@@ -33,10 +34,10 @@ export function RHFInputField({
           rows={4}
           {...register(name, {
             required: { message: `Empty Field: ${label}`, value: isRequired },
+            ...registerOptions,
           })}
           name={name}
           id={name}
-          placeholder={placeholder}
         />
       ) : (
         <input
@@ -56,6 +57,7 @@ export function RHFInputField({
                 return true;
               },
             },
+            ...registerOptions,
           })}
           id={name}
           name={name}

--- a/src/components/pharmacy/MedicationForm.tsx
+++ b/src/components/pharmacy/MedicationForm.tsx
@@ -43,10 +43,16 @@ export function MedicationForm({
           isRequired={editMedication == null} // Only required for adding new medicine
         />
         <RHFInputField
-          label="Warning Quantity (System will flag out when medication stock falls below this quantity)"
+          label="Warning Quantity (System will flag out when medication stock falls below this quantity). To remove warning, leave blank or 0."
           name="warning_quantity"
           type="number"
           isRequired={false}
+          validate={{
+            min: val =>
+              val == null ||
+              val >= 0 ||
+              'Warning Quantity should be greater than or equal to 0',
+          }}
         />
         <RHFInputField label="Notes" name="notes" type="text" />
         <div className="flex">

--- a/src/components/pharmacy/MedicationForm.tsx
+++ b/src/components/pharmacy/MedicationForm.tsx
@@ -30,17 +30,23 @@ export function MedicationForm({
           isRequired={true}
         />
         <RHFInputField label="Code" name="code" type="text" />
-        <DisplayField
-          label="Current Quantity"
-          content={
-            editMedication == null ? '-' : editMedication.quantity.toString()
-          }
-        />
+        {editMedication != null && (
+          <DisplayField
+            label="Current Quantity"
+            content={editMedication.quantity.toString()}
+          />
+        )}
         <RHFInputField
           label="Quantity to Add (Negative to subtract)"
           name="quantity_changed"
           type="number"
-          isRequired={true}
+          isRequired={editMedication == null} // Only required for adding new medicine
+        />
+        <RHFInputField
+          label="Warning Quantity (System will flag out when medication stock falls below this quantity)"
+          name="warning_quantity"
+          type="number"
+          isRequired={false}
         />
         <RHFInputField label="Notes" name="notes" type="text" />
         <div className="flex">

--- a/src/components/pharmacy/MedicationTable.tsx
+++ b/src/components/pharmacy/MedicationTable.tsx
@@ -1,5 +1,6 @@
 import { Button } from '@/components/Button';
 import { Medication } from '@/types/Medication';
+import { EyeIcon, PencilIcon } from '@heroicons/react/24/outline';
 import Link from 'next/link';
 
 export function MedicationTable({
@@ -14,6 +15,7 @@ export function MedicationTable({
           <tr className="border-b-2 border-gray-300">
             <th>Medication name</th>
             <th>Quantity</th>
+            <th>Warning Quantity</th>
             <th>Code</th>
             <th>Actions</th>
           </tr>
@@ -22,7 +24,7 @@ export function MedicationTable({
           {medications.length === 0 ? (
             <tr>
               <td
-                colSpan={3}
+                colSpan={5}
                 className="py-4 text-center text-xl text-gray-600"
               >
                 No medications found
@@ -39,22 +41,30 @@ export function MedicationTable({
   );
 }
 function MedicationItemRow({ medicine }: { medicine: Medication }) {
+  const isBelowWarningQuantity: boolean =
+    medicine.warning_quantity != null &&
+    medicine.quantity < medicine.warning_quantity;
   return (
-    <tr>
+    <tr
+      className={`${isBelowWarningQuantity ? 'bg-red-50' : 'bg-green-50'} transition-colors`}
+    >
       <td>{medicine.medicine_name}</td>
       <td>{medicine.quantity}</td>
+      <td>{medicine.warning_quantity || '-'}</td>
       <td>{medicine.code || 'N/A'}</td>
       <td>
-        <Link href={'/pharmacy/stock?edit=' + medicine.id} prefetch={false}>
-          <Button text="Edit" colour="green" />
-        </Link>
-        <Link
-          href={'/pharmacy/stock?view=' + medicine.id}
-          prefetch={false}
-          shallow={true}
-        >
-          <Button text="History" colour="blue" />
-        </Link>
+        <div className="flex gap-2">
+          <Link href={'/pharmacy/stock?edit=' + medicine.id} prefetch={false}>
+            <Button colour="green" Icon={<PencilIcon className="h-5 w-5" />} />
+          </Link>
+          <Link
+            href={'/pharmacy/stock?view=' + medicine.id}
+            prefetch={false}
+            shallow={true}
+          >
+            <Button colour="blue" Icon={<EyeIcon className="h-5 w-5" />} />
+          </Link>
+        </div>
       </td>
     </tr>
   );

--- a/src/components/pharmacy/stock/AddMedicationModal.tsx
+++ b/src/components/pharmacy/stock/AddMedicationModal.tsx
@@ -6,11 +6,16 @@ import { createMedicine } from '@/data/medication/createMedication';
 import { getMedication } from '@/data/medication/getMedications';
 import { useLoadingState } from '@/hooks/useLoadingState';
 import { useSaveOnWrite } from '@/hooks/useSaveOnWrite';
+import { PlusIcon } from '@heroicons/react/24/outline';
 import { useEffect, useState } from 'react';
 import { FieldValues, FormProvider, useForm } from 'react-hook-form';
 import toast from 'react-hot-toast';
 
-export function AddMedicationModal() {
+export function AddMedicationModal({
+  reloadAllMedications,
+}: {
+  reloadAllMedications: () => void;
+}) {
   const [isOpen, setIsOpen] = useState(false);
   const closeModal = () => setIsOpen(false);
   const { isLoading: isSubmitting, withLoading } = useLoadingState(false);
@@ -54,6 +59,7 @@ export function AddMedicationModal() {
               medicine_name: data.medicine_name.toString().trim(),
               code: data.code.toString().trim(),
               quantity: data.quantity_changed as number,
+              warning_quantity: data.warning_quantity as number,
               notes: data.notes as string,
             };
 
@@ -61,6 +67,7 @@ export function AddMedicationModal() {
             toast.success(`Added Medicine: ${med.medicine_name}`);
             useFormReturn.reset({});
             clearLocalStorageData();
+            reloadAllMedications();
             closeModal();
           });
 
@@ -79,8 +86,9 @@ export function AddMedicationModal() {
   return (
     <>
       <Button
-        text="Add New Medicine"
+        text="Add"
         colour="green"
+        Icon={<PlusIcon className="h-5 w-5" />}
         onClick={() => setIsOpen(true)}
       />
       <Modal

--- a/src/components/pharmacy/stock/EditMedicationModal.tsx
+++ b/src/components/pharmacy/stock/EditMedicationModal.tsx
@@ -56,6 +56,7 @@ export function EditMedicationModal({
       code: editMedication?.code || '',
       notes: editMedication?.notes || '',
       quantity_changed: null,
+      warning_quantity: editMedication?.warning_quantity || null,
     },
   });
 
@@ -99,6 +100,7 @@ export function EditMedicationModal({
                       medicine_name: data.medicine_name.trim(),
                       code: data.code.trim(),
                       quantityChange: Number(data.quantity_changed) || 0,
+                      warning_quantity: Number(data.warning_quantity) || null,
                       notes: data.notes as string,
                     };
 

--- a/src/components/records/consultation/MedicationOrderForm.tsx
+++ b/src/components/records/consultation/MedicationOrderForm.tsx
@@ -41,6 +41,46 @@ export function MedicationOrderForm({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [selectedOrder]);
 
+  const getInStockQuantityColour = (
+    medication: Medication | null
+  ): 'bg-red-200' | 'bg-amber-200' | 'bg-green-200' | '' => {
+    if (medication == null) {
+      return ''; // leave as grey
+    }
+
+    if (
+      medication.warning_quantity == null ||
+      medication.quantity >= medication.warning_quantity
+    ) {
+      return 'bg-green-200'; // highlight as green
+    }
+
+    if (medication.quantity < medication.warning_quantity) {
+      return 'bg-red-200'; // highlight as red
+    }
+
+    return '';
+  };
+
+  const getInStockQuantityText = (medication: Medication | null): string => {
+    if (medication == null) {
+      return '-';
+    }
+
+    if (
+      medication.warning_quantity == null ||
+      medication.quantity >= medication.warning_quantity
+    ) {
+      return medication.quantity.toString();
+    }
+
+    if (medication.quantity < medication.warning_quantity) {
+      return medication.quantity.toString() + ' (Low Quantity)';
+    }
+
+    return '-';
+  };
+
   const selectedMedicationId =
     useFormReturn.watch('medication').split(' ', 1)[0] || '';
 
@@ -110,12 +150,23 @@ export function MedicationOrderForm({
             <div className="grid grid-cols-2 gap-4">
               <DisplayField
                 label="In Stock"
+                highlight={
+                  medications == undefined || selectedMedicationId == ''
+                    ? ''
+                    : getInStockQuantityColour(
+                        medications.find(
+                          med => med.id.toString() == selectedMedicationId
+                        ) || null
+                      )
+                }
                 content={
                   medications == undefined || selectedMedicationId == ''
                     ? '-'
-                    : medications
-                        .find(med => med.id.toString() == selectedMedicationId)
-                        ?.quantity.toString() || '-'
+                    : getInStockQuantityText(
+                        medications.find(
+                          med => med.id.toString() == selectedMedicationId
+                        ) || null
+                      )
                 }
               />
               <RHFInputField
@@ -131,12 +182,6 @@ export function MedicationOrderForm({
               label="Dosage Instructions"
               placeholder="Dosage Instructions"
               isRequired={true}
-            />
-            <Button
-              type="button"
-              text="Cancel"
-              colour="red"
-              onClick={closeForm}
             />
             <Button type="submit" text="Submit" colour="green" />
           </form>

--- a/src/data/medication/patchMedication.ts
+++ b/src/data/medication/patchMedication.ts
@@ -2,7 +2,10 @@
 import { axiosInstance } from '@/lib/axiosInstance';
 import { Medication } from '@/types/Medication';
 
-type PatchMedication = Pick<Medication, 'medicine_name' | 'notes'> & {
+type PatchMedication = Pick<
+  Medication,
+  'medicine_name' | 'notes' | 'warning_quantity'
+> & {
   quantityChange: number;
 };
 export async function patchMedicine(

--- a/src/types/Medication.ts
+++ b/src/types/Medication.ts
@@ -3,5 +3,6 @@ export type Medication = {
   medicine_name: string;
   code: string;
   quantity: number;
+  warning_quantity: number | null;
   notes: string;
 };


### PR DESCRIPTION
Closes https://github.com/NUS-Project-SaBai/FrontEnd/issues/107
Backend PR: https://github.com/NUS-Project-SaBai/BackEnd/pull/145

Added a warning_quantity field to medication model. When the medication quantity for this medicine falls below the set warning quantity, the medicine team should be notified. This field can be set to null (and defaults as null) for medication that doesn't require this feature

The warning will show up on the following pages

### 1. Medication Stock (/pharmacy/stock)
<img width="1470" height="956" alt="Screenshot 2025-10-27 at 6 28 38 PM" src="https://github.com/user-attachments/assets/0f05cfd4-a102-4dae-804d-861e031cf0db" />

###  2. Orders (/pharmacy/orders)
<img width="1470" height="956" alt="Screenshot 2025-10-27 at 6 29 14 PM" src="https://github.com/user-attachments/assets/ba13a9e5-2f89-4a7e-806f-057d09bf4210" />

###  3. The orders form in the Consultation Page, when the user makes an order for a low quantity medicine. 
<img width="1470" height="956" alt="Screenshot 2025-10-27 at 6 29 30 PM" src="https://github.com/user-attachments/assets/7274c165-2bc3-4c92-9388-125682d078cb" />

Also updated button component and touched up miscellaneous UI quirks.