### PR TITLE
added utility function of isVisualAcuityPoor in Vital.ts along with regex pattern to flag values 6/12 or worse in patient consultation and patient records…

### DIFF
--- a/src/components/pharmacy/MedicationForm.tsx
+++ b/src/components/pharmacy/MedicationForm.tsx
@@ -10,10 +10,12 @@ export function MedicationForm({
   onSubmit,
   isSubmitting = false,
   editMedication = null,
+  isDirty = true
 }: {
   onSubmit: FormEventHandler;
   isSubmitting?: boolean;
   editMedication?: Medication | null;
+  isDirty?: boolean;
 }) {
   return (
     <div className="flex flex-col gap-4">
@@ -40,12 +42,14 @@ export function MedicationForm({
           label="Quantity to Add (Negative to subtract)"
           name="quantity_changed"
           type="number"
+          valueAsNumber={true}
           isRequired={editMedication == null} // Only required for adding new medicine
         />
         <RHFInputField
           label="Warning Quantity (System will flag out when medication stock falls below this quantity). To remove warning, leave blank or 0."
           name="warning_quantity"
           type="number"
+          valueAsNumber={true}
           isRequired={true}
           validate={{
             min: val =>
@@ -58,9 +62,24 @@ export function MedicationForm({
         <div className="flex">
           {isSubmitting ? (
             <LoadingUI message="Submitting medication..." />
-          ) : (
+          ) : editMedication == null ? (
             <Button text="Submit" colour="green" type="submit" />
-          )}
+          ) : isDirty ? (
+            <Button text="Submit edit" colour="green" type="submit" />
+          ) : (
+            <div className="flex flex-col gap-2">
+              <Button 
+                text="Submit edit" 
+                colour="red" // Note: Usually 'gray' is better for disabled states
+                type="submit" 
+                disabled={true} 
+              />
+              <p className="text-sm text-red-500 italic">
+                Make a change before submitting
+              </p>
+            </div>  
+          )
+          }
         </div>
       </form>
     </div>

--- a/src/components/pharmacy/MedicationForm.tsx
+++ b/src/components/pharmacy/MedicationForm.tsx
@@ -42,14 +42,12 @@ export function MedicationForm({
           label="Quantity to Add (Negative to subtract)"
           name="quantity_changed"
           type="number"
-          valueAsNumber={true}
           isRequired={editMedication == null} // Only required for adding new medicine
         />
-        <RHFInputField
+        {editMedication && <RHFInputField
           label="Warning Quantity (System will flag out when medication stock falls below this quantity). To remove warning, leave blank or 0."
           name="warning_quantity"
           type="number"
-          valueAsNumber={true}
           isRequired={false}
           validate={{
             min: val =>
@@ -57,20 +55,20 @@ export function MedicationForm({
               val >= 0 ||
               'Warning Quantity should be greater than or equal to 0',
           }}
-        />
+        />}
         <RHFInputField label="Notes" name="notes" type="text" />
         <div className="flex">
           {isSubmitting ? (
             <LoadingUI message="Submitting medication..." />
           ) : editMedication == null ? (
-            <Button text="Submit" colour="green" type="submit" />
+            <Button text="Submit" colour="green" type="submit"/> //used by AddMedicationModal
           ) : isDirty ? (
-            <Button text="Submit edit" colour="green" type="submit" />
+            <Button text="Submit edit" colour="green" type="submit" /> //EditMedicationModal, and got changes made
           ) : (
-            <div className="flex flex-col gap-2">
-              <Button 
+            <div className="flex flex-col gap-2">  
+              <Button               //EditMedicaitonModal, but got no changes
                 text="Submit edit" 
-                colour="red" // Note: Usually 'gray' is better for disabled states
+                colour="red" 
                 type="submit" 
                 disabled={true} 
               />

--- a/src/components/pharmacy/MedicationForm.tsx
+++ b/src/components/pharmacy/MedicationForm.tsx
@@ -50,7 +50,7 @@ export function MedicationForm({
           name="warning_quantity"
           type="number"
           valueAsNumber={true}
-          isRequired={true}
+          isRequired={false}
           validate={{
             min: val =>
               val == null ||

--- a/src/components/pharmacy/MedicationTable.tsx
+++ b/src/components/pharmacy/MedicationTable.tsx
@@ -42,12 +42,17 @@ export function MedicationTable({
 }
 function MedicationItemRow({ medicine }: { medicine: Medication }) {
   const ICON_CLASS_STYLE = 'h-6 w-6';
+
   const isBelowWarningQuantity: boolean =
     medicine.warning_quantity != null &&
     medicine.quantity < medicine.warning_quantity;
+  const isCriticallyLow: boolean = 
+    medicine.warning_quantity != null && 
+    medicine.quantity < (medicine.warning_quantity / 2)
+
   return (
     <tr
-      className={`${isBelowWarningQuantity ? 'bg-red-50' : 'bg-green-50'} transition-colors`}
+      className={`${isCriticallyLow? 'bg-red-100' :isBelowWarningQuantity ? 'bg-red-50' : 'bg-green-50'} transition-colors`}
     >
       <td>{medicine.medicine_name}</td>
       <td>{medicine.quantity}</td>

--- a/src/components/pharmacy/stock/AddMedicationModal.tsx
+++ b/src/components/pharmacy/stock/AddMedicationModal.tsx
@@ -59,7 +59,8 @@ export function AddMedicationModal({
               medicine_name: data.medicine_name.toString().trim(),
               code: data.code.toString().trim(),
               quantity: data.quantity_changed as number,
-              warning_quantity: data.warning_quantity as number,
+              //warning quantity is set to be 50% of input quantity
+              warning_quantity: Math.floor(data.quantity_changed / 2) as number, 
               notes: data.notes as string,
             };
 

--- a/src/components/pharmacy/stock/EditMedicationModal.tsx
+++ b/src/components/pharmacy/stock/EditMedicationModal.tsx
@@ -60,7 +60,7 @@ export function EditMedicationModal({
     },
   });
 
-  const {isDirty}  = useFormReturn.formState;
+  const { isDirty } = useFormReturn.formState;
 
   return (
     <Modal
@@ -137,7 +137,6 @@ export function EditMedicationModal({
             }}
             editMedication={editMedication}
             isDirty = {isDirty}
-
           />
         </FormProvider>
       ) : (

--- a/src/components/pharmacy/stock/EditMedicationModal.tsx
+++ b/src/components/pharmacy/stock/EditMedicationModal.tsx
@@ -60,6 +60,8 @@ export function EditMedicationModal({
     },
   });
 
+  const {isDirty}  = useFormReturn.formState;
+
   return (
     <Modal
       isOpen={editMedicationId != null}
@@ -134,6 +136,8 @@ export function EditMedicationModal({
               )();
             }}
             editMedication={editMedication}
+            isDirty = {isDirty}
+
           />
         </FormProvider>
       ) : (

--- a/src/components/records/vital/PastVitalTable.tsx
+++ b/src/components/records/vital/PastVitalTable.tsx
@@ -1,7 +1,7 @@
 import { DisplayField } from '@/components/DisplayField';
 import { ALL_CHILD_AGES } from '@/components/records/vital/ChildVitalsFields';
 import { GenderType } from '@/types/Gender';
-import { displayBMI, Vital } from '@/types/Vital';
+import { displayBMI, isVisualAcuityPoor, Vital } from '@/types/Vital';
 
 type VitalFieldsDataType = {
   label: string;
@@ -41,8 +41,16 @@ export function PastVitalTable({
     },
     { label: 'Heart Rate', value: vital.heart_rate || '' },
     { label: 'Temperature', value: vital.temperature },
-    { label: 'Right Eye', value: vital.right_eye_degree },
-    { label: 'Left Eye', value: vital.left_eye_degree },
+    {
+      label: 'Right Eye',
+      value: vital.right_eye_degree,
+      highlight: isVisualAcuityPoor(vital.right_eye_degree) ? 'bg-red-200' : '',
+    },
+    {
+      label: 'Left Eye',
+      value: vital.left_eye_degree,
+      highlight: isVisualAcuityPoor(vital.left_eye_degree) ? 'bg-red-200' : '',
+    },
     { label: '', value: '' },
     { label: 'Right Eye Pinhole', value: vital.right_eye_pinhole },
     { label: 'Left Eye Pinhole', value: vital.left_eye_pinhole },

--- a/src/types/Vital.ts
+++ b/src/types/Vital.ts
@@ -45,6 +45,44 @@ export type Vital = {
 };
 
 /*
+ Normalises visual acuity input to standard "6/X" format.
+ Handles notation like "6/20 + 2" where the addition value is added to the denominator.
+ Examples:
+ - "6/20 + 2" -> "6/22"
+ - "6/6" -> "6/6"
+ - "6/12 + 1" -> "6/13"
+ @param visualAcuity - The visual acuity value to normalize
+ @returns The normalized visual acuity string in "6/X" format, or the original string if it cannot be normalized
+*/
+export function normalizeVisualAcuity(
+  visualAcuity: string | undefined
+): string {
+  if (!visualAcuity) return '';
+
+  const trimmed = visualAcuity.trim();
+
+  //Match standard "6/X" format, already normalized
+  const standardFormat = trimmed.match(/^(\d+)\s*\/\s*(\d+)$/);
+  if (standardFormat) {
+    return trimmed;
+  }
+
+  //Handling of non-normalized notation like "6/20 + 2"
+  const matchWithAddition = trimmed.match(/^(\d+)\s*\/\s*(\d+)\s*\+\s*(\d+)$/);
+
+  if (matchWithAddition) {
+    //If regex finds a match, it returns the first 3 numbers and calculates new denominator
+    const numerator = parseFloat(matchWithAddition[1]);
+    const denominator = parseFloat(matchWithAddition[2]);
+    const addition = parseFloat(matchWithAddition[3]);
+    const newDenominator = denominator + addition;
+    return `${numerator}/${newDenominator}`;
+  }
+
+  return trimmed;
+}
+
+/*
  Returns boolean true if the denominator is >= 12 (indicating worse vision)\
  Checks if a visual acuity value indicates poor vision 6/12 or worse (eg. 6/12, 6/18, 6/24, etc.)
  Supports standard "6/X" notation where X is the denominator.
@@ -55,7 +93,9 @@ export type Vital = {
 export function isVisualAcuityPoor(visualAcuity: string | undefined): boolean {
   if (!visualAcuity) return false;
 
-  const match = visualAcuity.trim().match(/^(\d+)\s*\/\s*(\d+)$/);
+  const normalized = normalizeVisualAcuity(visualAcuity);
+  const match = normalized.match(/^(\d+)\s*\/\s*(\d+)$/);
+
   if (!match) return false;
 
   const numerator = parseFloat(match[1]);

--- a/src/types/Vital.ts
+++ b/src/types/Vital.ts
@@ -52,9 +52,9 @@ export type Vital = {
  - "6/6" -> "6/6"
  - "6/12 + 1" -> "6/13"
  @param visualAcuity - The visual acuity value to normalize
- @returns The normalized visual acuity string in "6/X" format, or the original string if it cannot be normalized
+ @returns The normalized visual acuity string in "6/X" format
 */
-export function normalizeVisualAcuity(
+export function normalizeVisualAcuityValues(
   visualAcuity: string | undefined
 ): string {
   if (!visualAcuity) return '';
@@ -93,7 +93,7 @@ export function normalizeVisualAcuity(
 export function isVisualAcuityPoor(visualAcuity: string | undefined): boolean {
   if (!visualAcuity) return false;
 
-  const normalized = normalizeVisualAcuity(visualAcuity);
+  const normalized = normalizeVisualAcuityValues(visualAcuity);
   const match = normalized.match(/^(\d+)\s*\/\s*(\d+)$/);
 
   if (!match) return false;

--- a/src/types/Vital.ts
+++ b/src/types/Vital.ts
@@ -44,6 +44,33 @@ export type Vital = {
   others: string;
 };
 
+/*
+ Returns boolean true if the denominator is >= 12 (indicating worse vision)\
+ Checks if a visual acuity value indicates poor vision 6/12 or worse (eg. 6/12, 6/18, 6/24, etc.)
+ Supports standard "6/X" notation where X is the denominator.
+@param visualAcuity - The visual acuity value to check
+@returns boolean true if the visual acuity value indicates poor vision
+*/
+
+export function isVisualAcuityPoor(visualAcuity: string | undefined): boolean {
+  if (!visualAcuity) return false;
+
+  const match = visualAcuity.trim().match(/^(\d+)\s*\/\s*(\d+)$/);
+  if (!match) return false;
+
+  const numerator = parseFloat(match[1]);
+  const denominator = parseFloat(match[2]);
+
+  if (numerator !== 6) {
+    console.log(
+      `Non standard visual acutiy numerator detected: ${visualAcuity}`
+    );
+    return false;
+  }
+
+  return denominator >= 12;
+}
+
 export function vitalFromJson(jsonObj: object): Vital | null {
   return jsonObj as Vital;
 }


### PR DESCRIPTION
<img width="980" height="681" alt="Screenshot 2025-12-04 at 11 57 49 AM" src="https://github.com/user-attachments/assets/6e9c70a3-4e72-4a6a-9ba4-db24def4e543" />

Description:
This PR aims to add visual highlighting to flag poor visual acuity values (6/12 and worse, denominator increasing) for right and left eyes in the patient's consultation and records page.

Features:
- Added isVisualAcuityPoor() utility in src/types/Vital.ts to detect poor visual acuity (returns true as long as denominator >= 12 in 6/X format)
- Updated PastVitalTable to highlight right eye and left eye fields with red background as long as visuala cuity is 6/12 or worse. This applies to both consultation and patient record pages via the PastVitaltable component