### PR TITLE
Add 'others' option to referral dropdown

### DIFF
--- a/src/components/records/consultation/ConsultationForm.tsx
+++ b/src/components/records/consultation/ConsultationForm.tsx
@@ -225,6 +225,10 @@ export function ConsultationForm({
                 value: 'GlassessFitting',
                 label: 'GlassessFitting [Within clinic]',
               },
+              {
+                value: "Others",
+                label: "Others"
+              }
             ]}
           />
           {showReferralNotes && (


### PR DESCRIPTION
Add 'others' option to referral dropdown for cases where categories might not be sufficient to describe the referral