### PR TITLE
Update registration modal image when taking pic using scan face modal

### DIFF
--- a/src/app/records/page.tsx
+++ b/src/app/records/page.tsx
@@ -104,6 +104,10 @@ export default function RecordPage() {
     setFaceFilteredPatients(null);
   };
 
+  function setRegistrationFace(picture: string | null) {
+    setFormDetails(old => ({ ...old, picture }))
+  }
+
   const filteringByFace = faceFilteredPatients !== null;
 
   return (
@@ -132,7 +136,8 @@ export default function RecordPage() {
                 isSubmitting={isSubmitting}
               />
             </FormProvider>
-            <PatientScanForm setFilteredPatients={setFaceFilteredPatients} />
+            <PatientScanForm setFilteredPatients={setFaceFilteredPatients}
+              setRegistrationFace={setRegistrationFace} />
           </div>
         </div>
       </div>

--- a/src/components/inputs/WebcamInput.tsx
+++ b/src/components/inputs/WebcamInput.tsx
@@ -23,7 +23,7 @@ export function WebcamInput({
   cameraIsOpenCallback,
 }: {
   imageDetails: string | null;
-  setImageDetails: Dispatch<SetStateAction<string | null>>;
+  setImageDetails: (picture: string | null) => void;
   cameraIsOpenCallback?: (isOpen: boolean) => void;
 }) {
   const [cameraIsOpen, toggleCameraOpen, setCameraIsOpen] = useToggle(false);

--- a/src/components/inputs/WebcamInput.tsx
+++ b/src/components/inputs/WebcamInput.tsx
@@ -3,8 +3,6 @@ import { Button } from '@/components/Button';
 import { useToggle } from '@/hooks/useToggle';
 import Image from 'next/image';
 import {
-  Dispatch,
-  SetStateAction,
   useCallback,
   useEffect,
   useRef,

--- a/src/components/registration/PatientScanForm.tsx
+++ b/src/components/registration/PatientScanForm.tsx
@@ -13,8 +13,10 @@ import { ScanFace } from 'lucide-react';
 
 export function PatientScanForm({
   setFilteredPatients,
+  setRegistrationFace
 }: {
   setFilteredPatients: Dispatch<SetStateAction<Patient[] | null>>;
+  setRegistrationFace: (picture: string | null) => void
 }) {
   const [isOpen, setIsOpen] = useState(false);
   const [cameraIsOpen, setCameraIsOpen] = useState(false);
@@ -48,6 +50,11 @@ export function PatientScanForm({
     setCameraIsOpen(isOpen);
   };
 
+  function setScannedFace(picture: string | null) {
+    setImgDetails(picture);
+    setRegistrationFace(picture);
+  }
+
   return (
     <>
       <Button
@@ -67,7 +74,7 @@ export function PatientScanForm({
         <div className="flex flex-col space-y-2">
           <WebcamInput
             imageDetails={imgDetails}
-            setImageDetails={setImgDetails}
+            setImageDetails={setScannedFace}
             cameraIsOpenCallback={cameraToggleCallback}
           />
           <div className="flex justify-center space-x-2">


### PR DESCRIPTION
After scanning face for facial recog, the photo will automatically be updated in the registration form so you don't have to take the photo twice

- **Update registration modal image when taking pic using scan face modal**
- **Remove unused imports**
