### PR TITLE
Fix vitals form madness

### DIFF
--- a/src/app/records/page.tsx
+++ b/src/app/records/page.tsx
@@ -95,7 +95,7 @@ export default function RecordPage() {
 
         const pubertyData = allPubertyFields.reduce(
           (acc, field) => {
-            const key = field.name;
+            const key = field[0].name;
             const value = fieldValues[key];
 
             if (value !== undefined && value !== '') {

--- a/src/app/records/page.tsx
+++ b/src/app/records/page.tsx
@@ -45,7 +45,7 @@ export default function RecordPage() {
 
   const useFormReturn = useForm({
     values: formDetails,
-    resetOptions: { keepDirtyValues: true },
+    // resetOptions: { keepDefaultValues: true }, // does not work as we set default values at field level for the new patient modal
   });
 
   useEffect(() => {
@@ -122,7 +122,11 @@ export default function RecordPage() {
           return;
         }
 
+        // useFormReturn.reset({ village_prefix: fieldValues.village_prefix }, { keepDefaultValues: true });
+        // keepDefaultValues does not work as we set default values at field level
+
         useFormReturn.reset({ village_prefix: fieldValues.village_prefix });
+
         clearLocalStorageData();
 
         toast.success('Patient Created!');

--- a/src/app/records/patient-vitals/page.tsx
+++ b/src/app/records/patient-vitals/page.tsx
@@ -17,6 +17,7 @@ export default async function PatientVitalPage({
 }: {
   searchParams: Promise<{ id: string; visit: string }>;
 }) {
+  console.log("WHY IS THIS COMPONENT RERENDERING")
   const { id: patientId, visit: visitId } = await searchParams;
   if (visitId == undefined) {
     return (
@@ -39,6 +40,7 @@ export default async function PatientVitalPage({
       date: visit == null ? new Date() : new Date(visit.date),
     })),
   ]);
+  // console.log("SERVER COMPONENT GROSS MOTOR: ", curVital.gross_motor)
   if (!patient) {
     return (
       <div className="p-2">

--- a/src/app/records/patient-vitals/page.tsx
+++ b/src/app/records/patient-vitals/page.tsx
@@ -17,7 +17,6 @@ export default async function PatientVitalPage({
 }: {
   searchParams: Promise<{ id: string; visit: string }>;
 }) {
-  console.log("WHY IS THIS COMPONENT RERENDERING")
   const { id: patientId, visit: visitId } = await searchParams;
   if (visitId == undefined) {
     return (
@@ -40,7 +39,6 @@ export default async function PatientVitalPage({
       date: visit == null ? new Date() : new Date(visit.date),
     })),
   ]);
-  // console.log("SERVER COMPONENT GROSS MOTOR: ", curVital.gross_motor)
   if (!patient) {
     return (
       <div className="p-2">

--- a/src/components/inputs/RHFBinaryOption.tsx
+++ b/src/components/inputs/RHFBinaryOption.tsx
@@ -1,4 +1,5 @@
-import { OptionData, RHFDropdown } from '@/components/inputs/RHFDropdown';
+import { OptionData } from '@/components/inputs/RHFDropdown';
+import { RHFCustomSelect } from './RHFCustomSelect';
 
 type RHFBinaryOptionProps = {
   name: string;
@@ -17,15 +18,15 @@ export function RHFBinaryOption({
   optionValue1 = 'Yes',
   optionLabel2 = 'No',
   optionValue2 = 'No',
-  defaultValue = '',
-  isRequired = false,
+  defaultValue,
+  isRequired = true,
 }: RHFBinaryOptionProps) {
   const yesNoOptions: OptionData[] = [
     { label: optionLabel1, value: optionValue1 },
     { label: optionLabel2, value: optionValue2 },
   ];
   return (
-    <RHFDropdown
+    <RHFCustomSelect
       label={label}
       name={name}
       options={yesNoOptions}

--- a/src/components/inputs/RHFCustomSelect.tsx
+++ b/src/components/inputs/RHFCustomSelect.tsx
@@ -51,14 +51,13 @@ export function RHFCustomSelect({
         }}
         defaultValue={defaultValue}
         render={({ field }) => {
-          // if (name === "gross_motor") console.log("current motor value in customSelect: ", field.value)
           return (
             <div className='flex flex-row flex-wrap gap-2'>
               {options.map(v => {
                 const currValOverride = watchedValue ?? defaultValue
                 function handleChange(v: string | number) {
-                  if (currValOverride === v) field.onChange(isRequired ? null : unselectedValue)
-                  else field.onChange(v)
+                  if (currValOverride === v && !isRequired) field.onChange(unselectedValue);
+                  else field.onChange(v);
                 }
                 const value = typeof v === "object" ? v.value : v
                 const label = typeof v === "object" ? v.label : v

--- a/src/components/inputs/RHFCustomSelect.tsx
+++ b/src/components/inputs/RHFCustomSelect.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { NAOption } from '@/constants';
 import { useEffect } from 'react';
 import { Controller, useFormContext } from 'react-hook-form';
 
@@ -22,25 +23,30 @@ export function RHFCustomSelect({
   options,
   defaultValue,
   isRequired = false,
-  unselectedValue,
+  unselectedValue = NAOption,
   className = '',
   optionClassName = ''
 }: RHFCustomSelectProps) {
   const {
     control,
     setValue,
-    formState: { errors, isSubmitted }
+    formState: { errors, isSubmitted },
+    watch
   } = useFormContext();
 
   // keep in sync if defaultValue prop changes
-  useEffect(() => {
-    if (defaultValue !== undefined)
-      setValue(name, defaultValue, { shouldValidate: true });
-  }, [defaultValue, name, setValue]);
+  // useEffect(() => {
+  //   if (defaultValue !== undefined)
+  //     setValue(name, defaultValue, { shouldValidate: true });
+  // }, [defaultValue, name, setValue]);
 
   const hasError = Boolean(errors[name] && isSubmitted);
   const errorMessage = (errors[name]?.message as string) || '';
-
+  const watchedValue = watch(name)
+  // if (name === "gross_motor") {
+  //   console.log("defaultValue in customSelect: ", defaultValue)
+  //   console.log("watch gross motor in customselect", watchedValue)
+  // }
   return (
     <div className={className}>
       <label htmlFor={name} className="mb-1 block text-sm font-medium">
@@ -56,11 +62,13 @@ export function RHFCustomSelect({
         }}
         defaultValue={defaultValue}
         render={({ field }) => {
+          // if (name === "gross_motor") console.log("current motor value in customSelect: ", field.value)
           return (
             <div className='flex flex-row flex-wrap gap-2'>
               {options.map(v => {
+                const currValOverride = watchedValue ?? defaultValue
                 function handleChange(v: string | number) {
-                  if (field.value === v) field.onChange(isRequired ? null : unselectedValue)
+                  if (currValOverride === v) field.onChange(isRequired ? null : unselectedValue)
                   else field.onChange(v)
                 }
                 const value = typeof v === "object" ? v.value : v
@@ -70,7 +78,7 @@ export function RHFCustomSelect({
                   value={value}
                   label={label}
                   className={optionClassName}
-                  selected={field.value === value}
+                  selected={currValOverride === value}
                   onChange={handleChange}
                 />
               }

--- a/src/components/inputs/RHFCustomSelect.tsx
+++ b/src/components/inputs/RHFCustomSelect.tsx
@@ -44,7 +44,7 @@ export function RHFCustomSelect({
   // TODO: possibly define all the form fields at the useForm level instead.
   useEffect(() => {
     if (defaultValue && !watchedValue) setValue(name, defaultValue)
-  },[defaultValue])
+  },[defaultValue, watchedValue, setValue, name])
 
   return (
     <div className={className}>

--- a/src/components/inputs/RHFCustomSelect.tsx
+++ b/src/components/inputs/RHFCustomSelect.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import { NAOption } from '@/constants';
-import { useEffect } from 'react';
 import { Controller, useFormContext } from 'react-hook-form';
 
 export type OptionData = { value: string | number; label: string } | string;
@@ -29,24 +28,14 @@ export function RHFCustomSelect({
 }: RHFCustomSelectProps) {
   const {
     control,
-    setValue,
     formState: { errors, isSubmitted },
     watch
   } = useFormContext();
 
-  // keep in sync if defaultValue prop changes
-  // useEffect(() => {
-  //   if (defaultValue !== undefined)
-  //     setValue(name, defaultValue, { shouldValidate: true });
-  // }, [defaultValue, name, setValue]);
-
   const hasError = Boolean(errors[name] && isSubmitted);
   const errorMessage = (errors[name]?.message as string) || '';
   const watchedValue = watch(name)
-  // if (name === "gross_motor") {
-  //   console.log("defaultValue in customSelect: ", defaultValue)
-  //   console.log("watch gross motor in customselect", watchedValue)
-  // }
+
   return (
     <div className={className}>
       <label htmlFor={name} className="mb-1 block text-sm font-medium">

--- a/src/components/inputs/RHFCustomSelect.tsx
+++ b/src/components/inputs/RHFCustomSelect.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { NAOption } from '@/constants';
+import { useEffect } from 'react';
 import { Controller, useFormContext } from 'react-hook-form';
 
 export type OptionData = { value: string | number; label: string } | string;
@@ -29,12 +30,21 @@ export function RHFCustomSelect({
   const {
     control,
     formState: { errors, isSubmitted },
-    watch
+    watch,
+    setValue
   } = useFormContext();
 
   const hasError = Boolean(errors[name] && isSubmitted);
   const errorMessage = (errors[name]?.message as string) || '';
   const watchedValue = watch(name)
+
+  // fix issue where after submitting the registration form, the form values are reset;
+  // but because the default values are set at field level (instead of during the useForm call),
+  // calling reset with keepDefaultValues does not actually preserve the default values
+  // TODO: possibly define all the form fields at the useForm level instead.
+  useEffect(() => {
+    if (defaultValue && !watchedValue) setValue(name, defaultValue)
+  },[defaultValue])
 
   return (
     <div className={className}>

--- a/src/components/records/patient/PatientForm.tsx
+++ b/src/components/records/patient/PatientForm.tsx
@@ -130,7 +130,8 @@ export function PatientForm({
           />
           <h2 className='mt-2'>Child Vitals</h2>
           {showChildVitals ? (<div>
-            <div className={gridStyle}>
+            {/* <div className={gridStyle}> */}
+            <div className="flex flex-row gap-6">
               <RHFCustomSelect
                 name="scoliosis"
                 label="Scoliosis"
@@ -156,8 +157,8 @@ export function PatientForm({
               curVital={EMPTY_VITAL}
               pubertyFields={allPubertyFields.filter(
                 field =>
-                  (field.gender == undefined || field.gender == gender) &&
-                  field.age.includes(age)
+                  (field[0].gender == undefined || field[0].gender == gender) &&
+                  field[0].age.includes(age)
               )}
             />
           </div>

--- a/src/components/records/patient/PatientForm.tsx
+++ b/src/components/records/patient/PatientForm.tsx
@@ -33,7 +33,7 @@ export function PatientForm({
   isEditing?: boolean;
 }) {
   const { village } = useContext(VillageContext);
-  const { control, formState, getValues, watch } = useFormContext();
+  const { control, formState, watch } = useFormContext();
   const genderDropdownOptions = [
     { label: 'Male', value: 'Male' },
     { label: 'Female', value: 'Female' },
@@ -63,7 +63,7 @@ export function PatientForm({
             label="Gender"
             name="gender"
             options={genderDropdownOptions}
-            defaultValue={getValues('gender') || ''}
+            defaultValue={undefined}
             isRequired={true}
           />
           <RHFInputField
@@ -94,22 +94,22 @@ export function PatientForm({
           <RHFBinaryOption
             label="POOR Card"
             name="poor"
-            defaultValue={getValues('poor') || 'No'}
+            defaultValue={'No'}
           />
           <RHFBinaryOption
             label="BS2 Card"
             name="bs2"
-            defaultValue={getValues('bs2') || 'No'}
+            defaultValue={'No'}
           />
           <RHFBinaryOption
             label="Sabai Card"
             name="sabai"
-            defaultValue={getValues('sabai') || 'No'}
+            defaultValue={'No'}
           />
           <RHFBinaryOption
             label="Receive Reports"
             name="to_get_report"
-            defaultValue={getValues('to_get_report') || 'No'}
+            defaultValue={'No'}
           />
           <RHFInputField
             name="drug_allergy"

--- a/src/components/records/vital/ChildVitalsFields.tsx
+++ b/src/components/records/vital/ChildVitalsFields.tsx
@@ -59,7 +59,6 @@ const allChildVitalsFields: InputFieldData[] = [
     label: 'Scoliosis',
     type: 'dropdown',
     age: ALL_CHILD_AGES,
-    // defaultValue: 'Normal',
     options: [
       { label: 'Normal', value: 'Normal' },
       { label: 'Abnormal', value: 'Abnormal' },
@@ -69,7 +68,6 @@ const allChildVitalsFields: InputFieldData[] = [
     name: 'pallor',
     label: 'Pallor',
     type: 'dropdown',
-    // defaultValue: 'No',
     age: ALL_CHILD_AGES,
     options: [
       { label: 'Yes', value: 'Yes' },
@@ -186,7 +184,6 @@ export function ChildVitalsFields({
   patient: Pick<Patient, 'date_of_birth' | 'gender'>;
   curVital: Vital;
 }) {
-  // console.log("ChildVitalsFields gross_motor curVital value: ", curVital.gross_motor)
   const patientYearsOld = getPatientAge(patient).year;
 
   const childVitalsFields = useMemo(
@@ -284,7 +281,6 @@ function VitalFieldRenderer({
   field: InputFieldData;
   curVital: Vital;
 }) {
-  // if (field.name === "gross_motor") console.log("VitalFieldRenderer motor: ", curVital[field.name]?.toString())
   switch (field.type) {
     case 'dropdown':
       return (

--- a/src/components/records/vital/ChildVitalsFields.tsx
+++ b/src/components/records/vital/ChildVitalsFields.tsx
@@ -304,7 +304,7 @@ function ChildVitalsSection({
     <div>
       <h2>Child Vitals</h2>
       <div className="flex flex-row">
-      {/* <div className="grids-col-1 grid gap-2 md:grid-cols-2"> */}
+        {/* <div className="grids-col-1 grid gap-2 md:grid-cols-2"> */}
         {childVitalsFields.map(field => (
           <VitalFieldRenderer
             key={field.name}
@@ -331,11 +331,11 @@ export function ChildPubertySection({
         <p>No Puberty Fields, Ensure gender and age is correct</p>
       ) : (
         <div className="flex flex-row flex-wrap">
-        {/* <div className="grids-col-1 grid gap-2 lg:grid-cols-3"> */}
-        {/* <div className="flex flex-col gap-2"> */}
+          {/* <div className="grids-col-1 grid gap-2 lg:grid-cols-3"> */}
+          {/* <div className="flex flex-col gap-2"> */}
           {pubertyFields.map(field => (
             // <div className='flex flex-row gap-4 rounded-lg mr-6 p-2 border-2 border-gray-50'>
-            <div className='flex flex-row gap-4 rounded-lg mr-6 p-2 bg-gray-50 shadow-sm mb-2'>
+            <div className='flex flex-row gap-4 rounded-lg mr-6 p-2 bg-gray-50 shadow-sm mb-2' key={field[0].name}>
               <VitalFieldRenderer
                 key={field[0].name}
                 field={field[0]}

--- a/src/components/records/vital/ChildVitalsFields.tsx
+++ b/src/components/records/vital/ChildVitalsFields.tsx
@@ -1,4 +1,5 @@
 import { RHFBinaryOption } from '@/components/inputs/RHFBinaryOption';
+import { RHFCustomSelect } from '@/components/inputs/RHFCustomSelect';
 import { OptionData, RHFDropdown } from '@/components/inputs/RHFDropdown';
 import { RHFInputField } from '@/components/inputs/RHFInputField';
 import { GenderType } from '@/types/Gender';
@@ -58,7 +59,7 @@ const allChildVitalsFields: InputFieldData[] = [
     label: 'Scoliosis',
     type: 'dropdown',
     age: ALL_CHILD_AGES,
-    defaultValue: 'Normal',
+    // defaultValue: 'Normal',
     options: [
       { label: 'Normal', value: 'Normal' },
       { label: 'Abnormal', value: 'Abnormal' },
@@ -68,7 +69,7 @@ const allChildVitalsFields: InputFieldData[] = [
     name: 'pallor',
     label: 'Pallor',
     type: 'dropdown',
-    defaultValue: 'No',
+    // defaultValue: 'No',
     age: ALL_CHILD_AGES,
     options: [
       { label: 'Yes', value: 'Yes' },
@@ -185,6 +186,7 @@ export function ChildVitalsFields({
   patient: Pick<Patient, 'date_of_birth' | 'gender'>;
   curVital: Vital;
 }) {
+  // console.log("ChildVitalsFields gross_motor curVital value: ", curVital.gross_motor)
   const patientYearsOld = getPatientAge(patient).year;
 
   const childVitalsFields = useMemo(
@@ -282,10 +284,11 @@ function VitalFieldRenderer({
   field: InputFieldData;
   curVital: Vital;
 }) {
+  // if (field.name === "gross_motor") console.log("VitalFieldRenderer motor: ", curVital[field.name]?.toString())
   switch (field.type) {
     case 'dropdown':
       return (
-        <RHFDropdown
+        <RHFCustomSelect
           defaultValue={curVital[field.name]?.toString()}
           {...field}
         />

--- a/src/components/records/vital/ChildVitalsFields.tsx
+++ b/src/components/records/vital/ChildVitalsFields.tsx
@@ -1,6 +1,6 @@
 import { RHFBinaryOption } from '@/components/inputs/RHFBinaryOption';
 import { RHFCustomSelect } from '@/components/inputs/RHFCustomSelect';
-import { OptionData, RHFDropdown } from '@/components/inputs/RHFDropdown';
+import { OptionData } from '@/components/inputs/RHFDropdown';
 import { RHFInputField } from '@/components/inputs/RHFInputField';
 import { GenderType } from '@/types/Gender';
 import { getPatientAge, Patient } from '@/types/Patient';
@@ -307,6 +307,7 @@ function VitalFieldRenderer({
       return (
         <RHFBinaryOption
           defaultValue={curVital[field.name]?.toString()}
+          isRequired={false}
           {...field}
         />
       );

--- a/src/components/records/vital/ChildVitalsFields.tsx
+++ b/src/components/records/vital/ChildVitalsFields.tsx
@@ -21,21 +21,21 @@ export const PUBERTY_AGES_12_17 = [
 
 type InputFieldData =
   | {
-      type: 'dropdown';
-      name: keyof Omit<Vital, 'id' | 'visit'>;
-      label: string;
-      defaultValue?: string;
-      options: OptionData[];
-      age: number[];
-      gender?: GenderType;
-    }
+    type: 'dropdown';
+    name: keyof Omit<Vital, 'id' | 'visit'>;
+    label: string;
+    defaultValue?: string;
+    options: OptionData[];
+    age: number[];
+    gender?: GenderType;
+  }
   | {
-      type: 'text' | 'yesNoOption' | 'number';
-      name: keyof Omit<Vital, 'id' | 'visit'>;
-      label: string;
-      age: number[];
-      gender?: GenderType;
-    };
+    type: 'text' | 'yesNoOption' | 'number';
+    name: keyof Omit<Vital, 'id' | 'visit'>;
+    label: string;
+    age: number[];
+    gender?: GenderType;
+  };
 const allChildVitalsFields: InputFieldData[] = [
   {
     type: 'dropdown',
@@ -106,8 +106,77 @@ const allChildVitalsFields: InputFieldData[] = [
   },
 ];
 
-export const allPubertyFields: InputFieldData[] = [
-  {
+export const allPubertyFields: InputFieldData[][] = [
+  // {
+  //   type: 'yesNoOption',
+  //   name: 'pubarche',
+  //   label: 'Pubarche',
+  //   age: PUBERTY_AGES_12_19
+  // },
+  // {
+  //   type: 'number',
+  //   name: 'pubarche_age',
+  //   label: 'Pubarche Age',
+  //   age: PUBERTY_AGES_12_19
+  //   },
+  //   {
+  //     type: 'yesNoOption',
+  //     name: 'thelarche',
+  //     label: 'Thelarche (F)',
+  //     age: PUBERTY_AGES_12_19,
+  //     gender: 'Female',
+  //   },
+  //   {
+  //     type: 'number',
+  //     name: 'thelarche_age',
+  //     label: 'Thelarche Age (F)',
+  //     age: PUBERTY_AGES_12_19,
+  //     gender: 'Female',
+  //   },
+  //   {
+  //     type: 'yesNoOption',
+  //     name: 'menarche',
+  //     label: 'Menarche (F)',
+  //     age: PUBERTY_AGES_12_19,
+  //     gender: 'Female',
+  //   },
+  //   {
+  //     type: 'text',
+  //     name: 'menarche_age',
+  //     label: 'Menarche Age (F)',
+  //     age: PUBERTY_AGES_12_19,
+  //     gender: 'Female',
+  //   },
+  //   {
+  //     type: 'yesNoOption',
+  //     name: 'voice_change',
+  //     label: 'Voice Change (M)',
+  //     age: PUBERTY_AGES_12_17,
+  //     gender: 'Male',
+  //   },
+  //   {
+  //     type: 'number',
+  //     name: 'voice_change_age',
+  //     label: 'Voice Change Age (M)',
+  //     age: PUBERTY_AGES_12_17,
+  //     gender: 'Male',
+  //   },
+  //   {
+  //     type: 'yesNoOption',
+  //     name: 'testicular_growth',
+  //     label: 'Testicular Growth >= 4ml (M)',
+  //     age: PUBERTY_AGES_12_17,
+  //     gender: 'Male',
+  //   },
+  //   {
+  //     type: 'number',
+  //     name: 'testicular_growth_age',
+  //     label: 'Testicular Growth Age (M)',
+  //     age: PUBERTY_AGES_12_17,
+  //     gender: 'Male',
+  //   },
+  // ];
+  [{
     type: 'yesNoOption',
     name: 'pubarche',
     label: 'Pubarche',
@@ -118,8 +187,8 @@ export const allPubertyFields: InputFieldData[] = [
     name: 'pubarche_age',
     label: 'Pubarche Age',
     age: PUBERTY_AGES_12_19
-  },
-  {
+  }],
+  [{
     type: 'yesNoOption',
     name: 'thelarche',
     label: 'Thelarche (F)',
@@ -132,8 +201,8 @@ export const allPubertyFields: InputFieldData[] = [
     label: 'Thelarche Age (F)',
     age: PUBERTY_AGES_12_19,
     gender: 'Female',
-  },
-  {
+  }],
+  [{
     type: 'yesNoOption',
     name: 'menarche',
     label: 'Menarche (F)',
@@ -146,8 +215,8 @@ export const allPubertyFields: InputFieldData[] = [
     label: 'Menarche Age (F)',
     age: PUBERTY_AGES_12_19,
     gender: 'Female',
-  },
-  {
+  }],
+  [{
     type: 'yesNoOption',
     name: 'voice_change',
     label: 'Voice Change (M)',
@@ -160,8 +229,8 @@ export const allPubertyFields: InputFieldData[] = [
     label: 'Voice Change Age (M)',
     age: PUBERTY_AGES_12_17,
     gender: 'Male',
-  },
-  {
+  }],
+  [{
     type: 'yesNoOption',
     name: 'testicular_growth',
     label: 'Testicular Growth >= 4ml (M)',
@@ -174,7 +243,7 @@ export const allPubertyFields: InputFieldData[] = [
     label: 'Testicular Growth Age (M)',
     age: PUBERTY_AGES_12_17,
     gender: 'Male',
-  },
+  }],
 ];
 
 export function ChildVitalsFields({
@@ -200,9 +269,9 @@ export function ChildVitalsFields({
     () =>
       allPubertyFields
         .filter(
-          field => field.gender == undefined || field.gender == patient.gender
+          field => field[0].gender == undefined || field[0].gender == patient.gender
         )
-        .filter(field => field.age.includes(patientYearsOld)),
+        .filter(field => field[0].age.includes(patientYearsOld)),
     [patient.gender, patientYearsOld]
   );
   return (
@@ -234,7 +303,8 @@ function ChildVitalsSection({
   return (
     <div>
       <h2>Child Vitals</h2>
-      <div className="grids-col-1 grid gap-2 md:grid-cols-2">
+      <div className="flex flex-row">
+      {/* <div className="grids-col-1 grid gap-2 md:grid-cols-2"> */}
         {childVitalsFields.map(field => (
           <VitalFieldRenderer
             key={field.name}
@@ -251,7 +321,7 @@ export function ChildPubertySection({
   pubertyFields,
   curVital,
 }: {
-  pubertyFields: InputFieldData[];
+  pubertyFields: InputFieldData[][];
   curVital: Vital;
 }) {
   return (
@@ -260,13 +330,23 @@ export function ChildPubertySection({
       {pubertyFields.length === 0 ? (
         <p>No Puberty Fields, Ensure gender and age is correct</p>
       ) : (
-        <div className="grids-col-1 grid gap-2 md:grid-cols-2">
+        <div className="flex flex-row flex-wrap">
+        {/* <div className="grids-col-1 grid gap-2 lg:grid-cols-3"> */}
+        {/* <div className="flex flex-col gap-2"> */}
           {pubertyFields.map(field => (
-            <VitalFieldRenderer
-              key={field.name}
-              field={field}
-              curVital={curVital}
-            />
+            // <div className='flex flex-row gap-4 rounded-lg mr-6 p-2 border-2 border-gray-50'>
+            <div className='flex flex-row gap-4 rounded-lg mr-6 p-2 bg-gray-50 shadow-sm mb-2'>
+              <VitalFieldRenderer
+                key={field[0].name}
+                field={field[0]}
+                curVital={curVital}
+              />
+              <VitalFieldRenderer
+                key={field[1].name}
+                field={field[1]}
+                curVital={curVital}
+              />
+            </div>
           ))}
         </div>
       )}

--- a/src/components/records/vital/VitalsForm.tsx
+++ b/src/components/records/vital/VitalsForm.tsx
@@ -9,7 +9,7 @@ import { ChildVitalsFields } from '@/components/records/vital/ChildVitalsFields'
 import { patchVital } from '@/data/vital/patchVital';
 import { Patient } from '@/types/Patient';
 import { displayBMI, Vital } from '@/types/Vital';
-import { FormEvent } from 'react';
+import { FormEvent, useEffect } from 'react';
 import { FieldValues, FormProvider, useForm } from 'react-hook-form';
 import toast from 'react-hot-toast';
 import { NAOption } from '@/constants';
@@ -27,6 +27,14 @@ export function VitalsForm({
   const useFormReturn = useForm();
   const { handleSubmit, reset, watch } = useFormReturn;
   const [formHeight, formWeight] = watch(['height', 'weight']);
+
+  // const [motor] = watch (['gross_motor'])
+  // console.log("gross_motor",motor)
+
+  useEffect(() => {
+    reset({})
+    console.log("form useeffect reset")
+  }, [curVital])
 
   // if the user hasn’t provided a new height/weight, fall back
   // to the current vital values (curVital.height, curVital.weight).
@@ -49,7 +57,8 @@ export function VitalsForm({
         patchVital(data as Vital).then(() => {
           // super jank because idh time to figure out why RHF keeps resetting this to the wrong value, 
           // and how it interacts with the default value given later
-          reset({ diabetes_mellitus: data.diabetes_mellitus });
+          // reset({ diabetes_mellitus: data.diabetes_mellitus });
+          console.log("RESETTED")
           toast.success('Updated Vital');
         });
       },

--- a/src/components/records/vital/VitalsForm.tsx
+++ b/src/components/records/vital/VitalsForm.tsx
@@ -34,7 +34,7 @@ export function VitalsForm({
   // their values set to these new values via the defaultValue prop.
   useEffect(() => {
     reset({})
-  }, [curVital])
+  }, [curVital, reset])
 
   // if the user hasn’t provided a new height/weight, fall back
   // to the current vital values (curVital.height, curVital.weight).

--- a/src/components/records/vital/VitalsForm.tsx
+++ b/src/components/records/vital/VitalsForm.tsx
@@ -28,12 +28,12 @@ export function VitalsForm({
   const { handleSubmit, reset, watch } = useFormReturn;
   const [formHeight, formWeight] = watch(['height', 'weight']);
 
-  // const [motor] = watch (['gross_motor'])
-  // console.log("gross_motor",motor)
-
+  // when curVital updates (i.e. after submitting the Vitals Form), reset the form values
+  // so that the text field values are cleared, showing the placeholders which are set from
+  // the new values in curVitals. The RHFCustomSelect and Dropdown components will have 
+  // their values set to these new values via the defaultValue prop.
   useEffect(() => {
     reset({})
-    console.log("form useeffect reset")
   }, [curVital])
 
   // if the user hasn’t provided a new height/weight, fall back
@@ -53,12 +53,7 @@ export function VitalsForm({
     handleSubmit(
       async (data: FieldValues) => {
         data.visit_id = visitId;
-        console.log("SUBMIT DATA", data)
         patchVital(data as Vital).then(() => {
-          // super jank because idh time to figure out why RHF keeps resetting this to the wrong value, 
-          // and how it interacts with the default value given later
-          // reset({ diabetes_mellitus: data.diabetes_mellitus });
-          console.log("RESETTED")
           toast.success('Updated Vital');
         });
       },

--- a/src/data/vital/patchVital.ts
+++ b/src/data/vital/patchVital.ts
@@ -4,6 +4,7 @@ import { axiosInstance } from '@/lib/axiosInstance';
 import { Vital } from '@/types/Vital';
 
 export async function patchVital(vital: Vital) {
+  console.log("patchvital")
   // remove empty fields to reduce data sent
   const jsonPayload = Object.fromEntries(
     Object.entries(vital).filter(([, v]) => v != undefined && v != '')


### PR DESCRIPTION
- **Finally figured out the issue**
- **Add documentation and remove console logs**
- **Switch all binaryOption components to use CustomSelect**

For some reason, the field value I get from the render prop in the Controller component is outdated, while the value from the watch method is updated. Swapping to that fixed the issue of the dropdown/selector switching to the wrong value.

However, that only fixed the gross_motor field. For the scoliosis and pallor fields, there was a defaultValue set in ChildVitalsFields that still kept setting the field to the wrong value. Removing that fixed the other 2 select fields.

The final issue is that after these 2 fixes, the select component jumps to the previous option before jumping back. The issue is that reset() is called right after patchVital, before the VitalsForm component has retrieved the updated data from backend. Thus, after resetting, the select component jumps to the previous (wrong) value. When the VitalsForm component finishes retrieving the updated data, it then jumps back.