### PR TITLE
Alert dialog when leaving forms

### DIFF
--- a/src/components/inputs/RHFCustomSelect.tsx
+++ b/src/components/inputs/RHFCustomSelect.tsx
@@ -43,7 +43,8 @@ export function RHFCustomSelect({
   // calling reset with keepDefaultValues does not actually preserve the default values
   // TODO: possibly define all the form fields at the useForm level instead.
   useEffect(() => {
-    if (defaultValue && !watchedValue) {
+    // Only set default when field is truly uninitialized (undefined), not just empty ("")
+    if (defaultValue !== undefined && watchedValue === undefined) {
       setValue(name, defaultValue, { shouldDirty: false });
     }
   }, [defaultValue, watchedValue, setValue, name]);

--- a/src/components/inputs/RHFCustomSelect.tsx
+++ b/src/components/inputs/RHFCustomSelect.tsx
@@ -25,26 +25,28 @@ export function RHFCustomSelect({
   isRequired = false,
   unselectedValue = NAOption,
   className = '',
-  optionClassName = ''
+  optionClassName = '',
 }: RHFCustomSelectProps) {
   const {
     control,
     formState: { errors, isSubmitted },
     watch,
-    setValue
+    setValue,
   } = useFormContext();
 
   const hasError = Boolean(errors[name] && isSubmitted);
   const errorMessage = (errors[name]?.message as string) || '';
-  const watchedValue = watch(name)
+  const watchedValue = watch(name);
 
   // fix issue where after submitting the registration form, the form values are reset;
   // but because the default values are set at field level (instead of during the useForm call),
   // calling reset with keepDefaultValues does not actually preserve the default values
   // TODO: possibly define all the form fields at the useForm level instead.
   useEffect(() => {
-    if (defaultValue && !watchedValue) setValue(name, defaultValue)
-  },[defaultValue, watchedValue, setValue, name])
+    if (defaultValue && !watchedValue) {
+      setValue(name, defaultValue, { shouldDirty: false });
+    }
+  }, [defaultValue, watchedValue, setValue, name]);
 
   return (
     <div className={className}>
@@ -62,27 +64,29 @@ export function RHFCustomSelect({
         defaultValue={defaultValue}
         render={({ field }) => {
           return (
-            <div className='flex flex-row flex-wrap gap-2'>
+            <div className="flex flex-row flex-wrap gap-2">
               {options.map(v => {
-                const currValOverride = watchedValue ?? defaultValue
+                const currValOverride = watchedValue ?? defaultValue;
                 function handleChange(v: string | number) {
-                  if (currValOverride === v && !isRequired) field.onChange(unselectedValue);
+                  if (currValOverride === v && !isRequired)
+                    field.onChange(unselectedValue);
                   else field.onChange(v);
                 }
-                const value = typeof v === "object" ? v.value : v
-                const label = typeof v === "object" ? v.label : v
-                return <Option
-                  key={value}
-                  value={value}
-                  label={label}
-                  className={optionClassName}
-                  selected={currValOverride === value}
-                  onChange={handleChange}
-                />
-              }
-              )}
+                const value = typeof v === 'object' ? v.value : v;
+                const label = typeof v === 'object' ? v.label : v;
+                return (
+                  <Option
+                    key={value}
+                    value={value}
+                    label={label}
+                    className={optionClassName}
+                    selected={currValOverride === value}
+                    onChange={handleChange}
+                  />
+                );
+              })}
             </div>
-          )
+          );
         }}
       />
 
@@ -96,22 +100,26 @@ function Option({
   label,
   className,
   selected,
-  onChange
+  onChange,
 }: {
   value: string | number;
   label: string;
   className: string;
   selected: boolean;
-  onChange: (v: string | number) => void
+  onChange: (v: string | number) => void;
 }) {
-  const borderColour = selected ? "text- border-2 border-black" : "border-2 border-gray-300";
-  return <button
-    className={`flex flex-col items-center justify-center px-2 py-1 bg-gray-100 rounded-sm ${borderColour} ${className}`}
-    onClick={(e) => {
-      e.preventDefault();
-      onChange(value)
-    }}
-  >
-    <div>{label}</div>
-  </button>
+  const borderColour = selected
+    ? 'text- border-2 border-black'
+    : 'border-2 border-gray-300';
+  return (
+    <button
+      className={`flex flex-col items-center justify-center rounded-sm bg-gray-100 px-2 py-1 ${borderColour} ${className}`}
+      onClick={e => {
+        e.preventDefault();
+        onChange(value);
+      }}
+    >
+      <div>{label}</div>
+    </button>
+  );
 }

--- a/src/components/records/consultation/ConsultationForm.tsx
+++ b/src/components/records/consultation/ConsultationForm.tsx
@@ -156,6 +156,14 @@ export function ConsultationForm({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isSubmitSuccessful]);
 
+  useEffect(() => {
+    if (isSubmitSuccessful && useFormReturn.formState.isDirty) {
+      const currentValues = useFormReturn.getValues();
+      reset(currentValues, { keepDirty: true });
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isSubmitSuccessful, useFormReturn.formState.isDirty]);
+
   // Helper function to process and validate diagnoses
   const processDiagnoses = (
     diagnoses: Array<{

--- a/src/components/records/consultation/ConsultationForm.tsx
+++ b/src/components/records/consultation/ConsultationForm.tsx
@@ -45,15 +45,9 @@ export function ConsultationForm({
   const useFormReturn = useForm();
   const loadedConsultIdRef = useRef<number | null>(null);
   const isLoadingRef = useRef(false);
-  const justSubmittedRef = useRef(false);
 
   useEffect(() => {
-    if (
-      !editConsultId &&
-      formDetails &&
-      Object.keys(formDetails).length > 0 &&
-      !justSubmittedRef.current
-    ) {
+    if (!editConsultId && formDetails && Object.keys(formDetails).length > 0) {
       useFormReturn.reset(formDetails);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -322,7 +316,7 @@ export function ConsultationForm({
         }
 
         // Clear form after successful submission
-        justSubmittedRef.current = true;
+
         reset({});
         clearLocalStorageData();
         if (isEditing && onEditComplete) {

--- a/src/components/records/consultation/ConsultationForm.tsx
+++ b/src/components/records/consultation/ConsultationForm.tsx
@@ -50,7 +50,8 @@ export function ConsultationForm({
     if (!editConsultId && formDetails && Object.keys(formDetails).length > 0) {
       useFormReturn.reset(formDetails);
     }
-  }, [editConsultId, formDetails, useFormReturn]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   useEffect(() => {
     if (editConsultId == null) {

--- a/src/components/records/consultation/ConsultationForm.tsx
+++ b/src/components/records/consultation/ConsultationForm.tsx
@@ -138,11 +138,6 @@ export function ConsultationForm({
   const referredFor = useFormReturn.watch('referred_for');
   const isEditing = editConsultId != null;
 
-  // Safeguard against leaving form with unsaved changes
-  useEffect(() => {
-    console.log('ConsultationForm hasUnsavedChanges:', hasUnsavedChanges);
-  }, [hasUnsavedChanges]);
-
   useSafeguardUnsavedChanges(
     hasUnsavedChanges,
     'You have unsaved changes to the consultation form. Are you sure you want to leave?',

--- a/src/components/records/consultation/ConsultationForm.tsx
+++ b/src/components/records/consultation/ConsultationForm.tsx
@@ -309,14 +309,17 @@ export function ConsultationForm({
               ? 'Medical Consult Updated!'
               : 'Medical Consult Completed!'
           );
-          reset({});
-          clearLocalStorageData();
-          if (isEditing && onEditComplete) {
-            onEditComplete();
-          }
         } catch (error) {
           console.error('Error submitting consultation form:', error);
           toast.error('Unknown Error');
+          return; // Don't clear form if there was an error
+        }
+
+        // Clear form after successful submission
+        reset({});
+        clearLocalStorageData();
+        if (isEditing && onEditComplete) {
+          onEditComplete();
         }
 
         // only submit the form if 'referred_for' is filled in and is not 'Not Referred'

--- a/src/components/records/consultation/ConsultationForm.tsx
+++ b/src/components/records/consultation/ConsultationForm.tsx
@@ -45,9 +45,15 @@ export function ConsultationForm({
   const useFormReturn = useForm();
   const loadedConsultIdRef = useRef<number | null>(null);
   const isLoadingRef = useRef(false);
+  const justSubmittedRef = useRef(false);
 
   useEffect(() => {
-    if (!editConsultId && formDetails && Object.keys(formDetails).length > 0) {
+    if (
+      !editConsultId &&
+      formDetails &&
+      Object.keys(formDetails).length > 0 &&
+      !justSubmittedRef.current
+    ) {
       useFormReturn.reset(formDetails);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -316,6 +322,7 @@ export function ConsultationForm({
         }
 
         // Clear form after successful submission
+        justSubmittedRef.current = true;
         reset({});
         clearLocalStorageData();
         if (isEditing && onEditComplete) {

--- a/src/components/records/consultation/ConsultationForm.tsx
+++ b/src/components/records/consultation/ConsultationForm.tsx
@@ -130,13 +130,13 @@ export function ConsultationForm({
     control,
     handleSubmit,
     reset,
-    formState: { isSubmitting, isSubmitSuccessful },
+    formState: { isSubmitting },
   } = useFormReturn;
   const referredFor = useFormReturn.watch('referred_for');
   const isEditing = editConsultId != null;
 
   useSafeguardUnsavedChanges(
-    useFormReturn.formState.isDirty && !isSubmitSuccessful,
+    useFormReturn.formState.isDirty,
     'You have unsaved changes to the consultation form. Are you sure you want to leave?',
     () => {
       // When user confirms they want to leave, clear the form state
@@ -144,25 +144,6 @@ export function ConsultationForm({
       clearLocalStorageData();
     }
   );
-
-  useEffect(() => {
-    if (isSubmitSuccessful) {
-      reset({});
-      clearLocalStorageData();
-      if (isEditing && onEditComplete) {
-        onEditComplete();
-      }
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [isSubmitSuccessful]);
-
-  useEffect(() => {
-    if (isSubmitSuccessful && useFormReturn.formState.isDirty) {
-      const currentValues = useFormReturn.getValues();
-      reset(currentValues, { keepDirty: true });
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [isSubmitSuccessful, useFormReturn.formState.isDirty]);
 
   // Helper function to process and validate diagnoses
   const processDiagnoses = (
@@ -328,6 +309,11 @@ export function ConsultationForm({
               ? 'Medical Consult Updated!'
               : 'Medical Consult Completed!'
           );
+          reset({});
+          clearLocalStorageData();
+          if (isEditing && onEditComplete) {
+            onEditComplete();
+          }
         } catch (error) {
           console.error('Error submitting consultation form:', error);
           toast.error('Unknown Error');

--- a/src/components/records/vital/VitalsForm.tsx
+++ b/src/components/records/vital/VitalsForm.tsx
@@ -35,11 +35,16 @@ export function VitalsForm({
     mode: 'onBlur',
     reValidateMode: 'onBlur',
   });
-  const { handleSubmit, reset, watch, formState } = useFormReturn;
+  const {
+    handleSubmit,
+    reset,
+    watch,
+    formState: { isDirty, isSubmitSuccessful },
+  } = useFormReturn;
   const [formHeight, formWeight] = watch(['height', 'weight']);
 
   useSafeguardUnsavedChanges(
-    formState.isDirty,
+    isDirty && !isSubmitSuccessful,
     'You have unsaved changes to the vitals form. Are you sure you want to leave?',
     () => {
       reset({});

--- a/src/components/records/vital/VitalsForm.tsx
+++ b/src/components/records/vital/VitalsForm.tsx
@@ -71,11 +71,17 @@ export function VitalsForm({
 
     handleSubmit(
       async (data: FieldValues) => {
-        data.visit_id = visitId;
-        patchVital(data as Vital).then(() => {
-          reset({});
+        try {
+          data.visit_id = visitId;
+          await patchVital(data as Vital);
           toast.success('Updated Vital');
-        });
+        } catch (error) {
+          toast.error('Error updating vital');
+          return;
+        }
+
+        // Clear form after successful submission
+        reset({});
       },
       () => {
         toast.error('Invalid/Missing Input');

--- a/src/components/records/vital/VitalsForm.tsx
+++ b/src/components/records/vital/VitalsForm.tsx
@@ -76,7 +76,8 @@ export function VitalsForm({
           await patchVital(data as Vital);
           toast.success('Updated Vital');
         } catch (error) {
-          toast.error('Error updating vital');
+          console.error('Error updating vital:', error);
+          toast.error('Unknown Error');
           return;
         }
 

--- a/src/components/records/vital/VitalsForm.tsx
+++ b/src/components/records/vital/VitalsForm.tsx
@@ -26,7 +26,7 @@ export function VitalsForm({
   visitId: string;
   curVital: Vital; // can be EMPTY_VITAL
 }) {
-  const [formDetails, setFormDetails, clearLocalStorageData] = useSaveOnWrite(
+  const [, , clearLocalStorageData] = useSaveOnWrite(
     'VitalsForm',
     {} as FieldValues,
     [visitId, curVital]

--- a/src/components/records/vital/VitalsForm.tsx
+++ b/src/components/records/vital/VitalsForm.tsx
@@ -39,12 +39,12 @@ export function VitalsForm({
     handleSubmit,
     reset,
     watch,
-    formState: { isDirty, isSubmitSuccessful },
+    formState: { isDirty },
   } = useFormReturn;
   const [formHeight, formWeight] = watch(['height', 'weight']);
 
   useSafeguardUnsavedChanges(
-    isDirty && !isSubmitSuccessful,
+    isDirty,
     'You have unsaved changes to the vitals form. Are you sure you want to leave?',
     () => {
       reset({});
@@ -54,22 +54,6 @@ export function VitalsForm({
   useEffect(() => {
     reset({});
   }, [curVital, reset]);
-
-  // Reset form after successful submission
-  useEffect(() => {
-    if (isSubmitSuccessful) {
-      reset({});
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [isSubmitSuccessful]);
-
-  useEffect(() => {
-    if (isSubmitSuccessful && useFormReturn.formState.isDirty) {
-      const currentValues = useFormReturn.getValues();
-      reset(currentValues, { keepDirty: true });
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [isSubmitSuccessful, useFormReturn.formState.isDirty]);
 
   // if the user hasn’t provided a new height/weight, fall back
   // to the current vital values (curVital.height, curVital.weight).
@@ -89,6 +73,7 @@ export function VitalsForm({
       async (data: FieldValues) => {
         data.visit_id = visitId;
         patchVital(data as Vital).then(() => {
+          reset({});
           toast.success('Updated Vital');
         });
       },

--- a/src/components/records/vital/VitalsForm.tsx
+++ b/src/components/records/vital/VitalsForm.tsx
@@ -51,10 +51,25 @@ export function VitalsForm({
       clearLocalStorageData();
     }
   );
-  
   useEffect(() => {
-    reset({})
+    reset({});
   }, [curVital, reset]);
+
+  // Reset form after successful submission
+  useEffect(() => {
+    if (isSubmitSuccessful) {
+      reset({});
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isSubmitSuccessful]);
+
+  useEffect(() => {
+    if (isSubmitSuccessful && useFormReturn.formState.isDirty) {
+      const currentValues = useFormReturn.getValues();
+      reset(currentValues, { keepDirty: true });
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isSubmitSuccessful, useFormReturn.formState.isDirty]);
 
   // if the user hasn’t provided a new height/weight, fall back
   // to the current vital values (curVital.height, curVital.weight).

--- a/src/components/records/vital/VitalsForm.tsx
+++ b/src/components/records/vital/VitalsForm.tsx
@@ -13,7 +13,7 @@ import useSafeguardUnsavedChanges from '@/hooks/safeguardUnsavedChanges';
 import { useSaveOnWrite } from '@/hooks/useSaveOnWrite';
 import { Patient } from '@/types/Patient';
 import { displayBMI, validateVisualAcuity, Vital } from '@/types/Vital';
-import { FormEvent, useEffect, useState } from 'react';
+import { FormEvent } from 'react';
 import { FieldValues, FormProvider, useForm } from 'react-hook-form';
 import toast from 'react-hot-toast';
 
@@ -35,19 +35,11 @@ export function VitalsForm({
     mode: 'onBlur',
     reValidateMode: 'onBlur',
   });
-  const { handleSubmit, reset, watch } = useFormReturn;
+  const { handleSubmit, reset, watch, formState } = useFormReturn;
   const [formHeight, formWeight] = watch(['height', 'weight']);
-  const [hasUnsavedChanges, setHasUnsavedChanges] = useState(false);
-
-  const formValues = useFormReturn.watch();
-  useEffect(() => {
-    if (formValues && Object.keys(formValues).length > 0) {
-      setHasUnsavedChanges(true);
-    }
-  }, [formValues]);
 
   useSafeguardUnsavedChanges(
-    hasUnsavedChanges,
+    formState.isDirty,
     'You have unsaved changes to the vitals form. Are you sure you want to leave?',
     () => {
       reset({});

--- a/src/components/referrals/ReferralStateDropdown.tsx
+++ b/src/components/referrals/ReferralStateDropdown.tsx
@@ -4,6 +4,7 @@ import { useLoadingState } from '@/hooks/useLoadingState';
 import { Referral } from '@/types/Referral';
 import { useState } from 'react';
 import toast from 'react-hot-toast';
+
 import {
   Select,
   SelectContent,
@@ -12,7 +13,13 @@ import {
   SelectValue,
 } from '../ui/select';
 
-export function ReferralStateDropdown({ referral }: { referral: Referral }) {
+export function ReferralStateDropdown({
+  referral,
+  onUpdate,
+}: {
+  referral: Referral;
+  onUpdate?: (referralId: number, updatedReferral: Referral) => void;
+}) {
   const referralState = [
     'None',
     'New',
@@ -37,7 +44,11 @@ export function ReferralStateDropdown({ referral }: { referral: Referral }) {
     });
     patch()
       .then(() => {
+        if (onUpdate) {
+          onUpdate(referral.id, { ...referral, referral_state: value });
+        }
         setReferralStatus(value);
+  
         toast.success('Updated successfully!');
       })
       .catch(() => toast.error('Failed to update'));

--- a/src/hooks/safeguardUnsavedChanges.ts
+++ b/src/hooks/safeguardUnsavedChanges.ts
@@ -1,0 +1,66 @@
+import { usePathname } from 'next/navigation';
+import { useEffect, useRef } from 'react';
+
+export default function useSafeguardUnsavedChanges(
+  isDirty: boolean,
+  message: string,
+  onConfirm?: () => void
+) {
+  const pathname = usePathname();
+
+  const isDirtyRef = useRef(isDirty);
+  const onConfirmRef = useRef(onConfirm);
+
+  isDirtyRef.current = isDirty;
+  onConfirmRef.current = onConfirm;
+
+  useEffect(() => {
+    const handleClick = (e: MouseEvent) => {
+      const target = e.target as HTMLElement;
+      const link = target.closest('a[href]') as HTMLAnchorElement | null;
+
+      if (!link || !link.href) return;
+      const linkUrl = new URL(link.href);
+
+      if (
+        linkUrl.pathname === pathname &&
+        linkUrl.search === window.location.search
+      ) {
+        return;
+      }
+
+      if (isDirtyRef.current) {
+        if (window.confirm(message)) {
+          isDirtyRef.current = false;
+        } else {
+          e.preventDefault();
+          e.stopPropagation(); //kills event before it reaches the Next.js Link component
+        }
+      }
+    };
+
+    // Handle pressing of back button
+    const handlePopState = (e: PopStateEvent) => {
+      if (isDirtyRef.current) {
+        if (window.confirm(message)) {
+          isDirtyRef.current = false;
+        } else {
+          // Push state to "undo" the back button action
+          window.history.pushState(null, '', window.location.href);
+          e.preventDefault();
+        }
+      }
+    };
+
+    window.history.pushState(null, '', window.location.href);
+
+    document.addEventListener('click', handleClick, true);
+    window.addEventListener('popstate', handlePopState);
+
+    return () => {
+      document.removeEventListener('click', handleClick, true);
+      window.removeEventListener('popstate', handlePopState);
+    };
+    //ref handles the life values
+  }, [message, pathname]);
+}

--- a/src/hooks/safeguardUnsavedChanges.ts
+++ b/src/hooks/safeguardUnsavedChanges.ts
@@ -39,27 +39,10 @@ export default function useSafeguardUnsavedChanges(
       }
     };
 
-    // Handle pressing of back button
-    const handlePopState = (e: PopStateEvent) => {
-      if (isDirtyRef.current) {
-        if (window.confirm(message)) {
-          isDirtyRef.current = false;
-        } else {
-          // Push state to "undo" the back button action
-          window.history.pushState(null, '', window.location.href);
-          e.preventDefault();
-        }
-      }
-    };
-
-    window.history.pushState(null, '', window.location.href);
-
     document.addEventListener('click', handleClick, true);
-    window.addEventListener('popstate', handlePopState);
 
     return () => {
       document.removeEventListener('click', handleClick, true);
-      window.removeEventListener('popstate', handlePopState);
     };
     //ref handles the life values
   }, [message, pathname]);


### PR DESCRIPTION
This PR aims to alert users when they are clicking on other components in the navbar by adding the useSafeguardUnsavedChanges hook for navigation blocking, designed to prevent users from accidentally navigating away from forms with unsaved data.