### PR TITLE
Fix bug in editing consult

### DIFF
--- a/src/components/records/consultation/ConsultationForm.tsx
+++ b/src/components/records/consultation/ConsultationForm.tsx
@@ -12,6 +12,7 @@ import { deleteDiagnosis } from '@/data/diagnosis/deleteDiagnosis';
 import { getDiagnosisByConsult } from '@/data/diagnosis/getDiagnosis';
 import { patchDiagnosis } from '@/data/diagnosis/patchDiagnosis';
 import { createReferral } from '@/data/referrals/createReferral';
+import { patchReferralByConsultId } from '@/data/referrals/patchReferral';
 import { useSaveOnWrite } from '@/hooks/useSaveOnWrite';
 import { ConsultMedicationOrder } from '@/types/ConsultMedicationOrder';
 import { Patient } from '@/types/Patient';
@@ -313,15 +314,22 @@ export function ConsultationForm({
             referralPayload['referral_outcome'] = '';
 
             try {
-              const result = createReferral(referralPayload);
-              result
-                .then(
-                  () => {
-                    toast.success('Referral submitted!');
-                  },
-                  () => console.log('error')
-                )
-                .catch(() => toast.error('Error submitting consultation form'));
+              if (isEditing) {
+                patchReferralByConsultId(
+                  referralPayload,
+                  Number(consultID)
+                ).catch(() => toast.error('Error updating referral'));
+              } else {
+                const result = createReferral(referralPayload);
+                result
+                  .then(
+                    () => {
+                      toast.success('Referral submitted!');
+                    },
+                    () => console.log('error')
+                  )
+                  .catch(() => toast.error('Error creating referral'));
+              }
             } catch (error) {
               console.error('Error submitting referral form:', error);
               toast.error('Unknown Error');

--- a/src/data/referrals/patchReferral.ts
+++ b/src/data/referrals/patchReferral.ts
@@ -9,3 +9,13 @@ export async function patchReferral(
   const data = (await axiosInstance.patch(`/referrals/${id}/`, payload)).data;
   return data;
 }
+
+export async function patchReferralByConsultId(
+  payload: Partial<Referral>,
+  consultId: number
+): Promise<void> {
+  const data = (
+    await axiosInstance.patch(`/referrals/?consult_id=${consultId}`, payload)
+  ).data;
+  return data;
+}


### PR DESCRIPTION
Fix bug where a referral is created with every edit of consult.

Still has bug where if the referred_for is changed to "Not Referred", it is still shown in referred page. 

Probably a good idea to just throw all the data to the backend, and let the backend api process the adding to the various fields.